### PR TITLE
ci: harden GHCR publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,7 +130,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Preflight: require PAT for cross-namespace push
+      - name: "Preflight: require PAT for cross-namespace push"
         if: ${{ env.DO_PUSH == 'true' && env.PUBLISH_IMAGE != github.repository && !secrets.GHCR_PAT }}
         run: |
           echo "Cross-namespace publish to ghcr.io/${{ env.PUBLISH_IMAGE }} requires GHCR_PAT (write:packages) and optional GHCR_USERNAME." >&2


### PR DESCRIPTION
### **User description**
Restrict GITHUB_TOKEN login to same-namespace publishes; lowercase PUBLISH_IMAGE; default PAT username to github.repository_owner; preflight for cross-namespace pushes without PAT; add top-level packages: write; gate pushing and scanning via DO_PUSH; fix YAML quoting for preflight step.


___

### **PR Type**
Other


___

### **Description**
- Fix YAML quoting for preflight step name


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish.yml</strong><dd><code>Fix YAML quoting for step name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish.yml

- Add double quotes around preflight step name to fix YAML syntax


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/18/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

