### PR TITLE
fix(data_cleaner): remove when cleaning demo data

### DIFF
--- a/app/models/demo/data_cleaner.rb
+++ b/app/models/demo/data_cleaner.rb
@@ -20,6 +20,7 @@ class Demo::DataCleaner
       Budget.delete_all if defined?(Budget)
       Category.delete_all if defined?(Category)
       Subscription.delete_all if defined?(Subscription)
+      Session.delete_all if defined?(Session)
       User.delete_all if defined?(User)
 
       # Accounts and their polymorphic dependents


### PR DESCRIPTION
### **User description**
Add deletion of Session records in the demo data cleaner so session
objects do not persist between demo runs. This prevents stale or
authenticated session state from affecting repeatable demo setups and
ensures a clean environment when recreating demo users and accounts.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `Session.delete_all` to demo data cleaner

- Prevents stale session state between demo runs

- Ensures clean environment for repeatable demos


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Demo Data Cleaner"] --> B["Delete Sessions"]
  B --> C["Clean Environment"]
  C --> D["Repeatable Demo Setup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_cleaner.rb</strong><dd><code>Add session deletion to demo cleaner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/models/demo/data_cleaner.rb

<ul><li>Added <code>Session.delete_all</code> call to <code>destroy_everything!</code> method<br> <li> Positioned after other child table deletions for proper cleanup order</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/27/files#diff-296a2b7ce2c550d5e435778125249767af227561d5e77de5c3a141e01a7fa445">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

