### PR TITLE
Fix/tabs darkmode signout issues

### DIFF
--- a/app/components/DS/menu_item.rb
+++ b/app/components/DS/menu_item.rb
@@ -58,7 +58,8 @@ class DS::MenuItem < DesignSystemComponent
       else
         # Rails 8.1: Default to _top frame for menu items to break out of any parent frames
         # This ensures navigation works correctly when menu is inside a Turbo Frame
-        data = data.merge(turbo_frame: "_top") if variant == :link
+        # Apply to both links and buttons (especially for logout which uses button_to)
+        data = data.merge(turbo_frame: "_top") if variant == :link || (variant == :button && method == :delete)
       end
 
       merged_opts.merge(data: data)

--- a/app/components/shadcn/tabs_component.html.erb
+++ b/app/components/shadcn/tabs_component.html.erb
@@ -21,7 +21,7 @@
         data-tab-value="<%= tab.value %>"
         data-action="click->shadcn--tabs#selectTab"
         tabindex="<%= tab.active ? '0' : '-1' %>"
-        class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 flex-1 gap-2 <%= tab.active ? 'bg-white theme-dark:bg-gray-700 text-primary shadow-sm' : 'text-secondary hover:bg-surface-inset-hover' %>"
+        class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 flex-1 gap-2 relative z-10 <%= tab.active ? 'bg-white theme-dark:bg-gray-700 text-primary shadow-sm' : 'text-secondary hover:bg-surface-inset-hover' %>"
       >
         <% if tab.icon %>
           <%= helpers.icon tab.icon, size: "sm" %>

--- a/app/components/shadcn/tabs_component.html.erb
+++ b/app/components/shadcn/tabs_component.html.erb
@@ -21,7 +21,8 @@
         data-tab-value="<%= tab.value %>"
         data-action="click->shadcn--tabs#selectTab"
         tabindex="<%= tab.active ? '0' : '-1' %>"
-        class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 flex-1 gap-2 relative z-10 <%= tab.active ? 'bg-white theme-dark:bg-gray-700 text-primary shadow-sm' : 'text-secondary hover:bg-surface-inset-hover' %>"
+        class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 flex-1 gap-2 relative z-10 pointer-events-auto <%= tab.active ? 'bg-white theme-dark:bg-gray-700 text-primary shadow-sm' : 'text-secondary hover:bg-surface-inset-hover' %>"
+        style="pointer-events: auto !important;"
       >
         <% if tab.icon %>
           <%= helpers.icon tab.icon, size: "sm" %>

--- a/app/components/shadcn/tabs_component.html.erb
+++ b/app/components/shadcn/tabs_component.html.erb
@@ -19,10 +19,8 @@
         aria-controls="panel-<%= identifier %>-<%= tab.value %>"
         data-shadcn--tabs-target="trigger"
         data-tab-value="<%= tab.value %>"
-        data-action="click->shadcn--tabs#selectTab"
         tabindex="<%= tab.active ? '0' : '-1' %>"
-        class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 flex-1 gap-2 relative z-10 pointer-events-auto <%= tab.active ? 'bg-white theme-dark:bg-gray-700 text-primary shadow-sm' : 'text-secondary hover:bg-surface-inset-hover' %>"
-        style="pointer-events: auto !important;"
+        class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 flex-1 gap-2 relative z-10 <%= tab.active ? 'bg-white theme-dark:bg-gray-700 text-primary shadow-sm' : 'text-secondary hover:bg-surface-inset-hover' %>"
       >
         <% if tab.icon %>
           <%= helpers.icon tab.icon, size: "sm" %>

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,7 +24,11 @@ class SessionsController < ApplicationController
 
   def destroy
     @session.destroy
-    redirect_to new_session_path, notice: t(".logout_successful")
+    
+    # Rails 8.1: Use status: :see_other for Turbo redirect compatibility
+    # This ensures Turbo Drive correctly handles the logout redirect
+    # Without this, Turbo may not process the redirect properly from a button_to form
+    redirect_to new_session_path, notice: t(".logout_successful"), status: :see_other
   end
 
   private

--- a/app/javascript/controllers/shadcn/tabs_controller.js
+++ b/app/javascript/controllers/shadcn/tabs_controller.js
@@ -29,12 +29,17 @@ export default class extends Controller {
 
   // Handle tab selection
   selectTab(event) {
+    // Rails 8.1: Use event.target for better reliability across themes
+    // event.currentTarget may not be set correctly in some cases (e.g., dark mode with overlays)
+    // Find the button element using closest to handle nested elements (icons, etc.)
+    const trigger = event.target.closest("button[data-shadcn--tabs-target='trigger']");
+    if (!trigger) return;
+
     // Only prevent default for buttons, let the event bubble normally
-    if (event.currentTarget.tagName === "BUTTON") {
+    if (trigger.tagName === "BUTTON") {
       event.preventDefault();
     }
 
-    const trigger = event.currentTarget;
     const value = trigger.dataset.tabValue;
 
     if (value) {

--- a/app/javascript/controllers/shadcn/tabs_controller.js
+++ b/app/javascript/controllers/shadcn/tabs_controller.js
@@ -26,19 +26,7 @@ export default class extends Controller {
     // Rails 8.1: Explicitly attach click listeners to all triggers for better reliability
     // This ensures clicks work even in dark mode with overlays or nested SVG elements
     // Stimulus data-action can sometimes be blocked by CSS layers in dark mode
-    this.triggerClickHandlers = new Map();
-    this.triggerTargets.forEach((trigger) => {
-      const handler = (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const value = trigger.dataset.tabValue;
-        if (value) {
-          this.activateTab(value, true);
-        }
-      };
-      this.triggerClickHandlers.set(trigger, handler);
-      trigger.addEventListener("click", handler, { capture: true });
-    });
+    this.attachClickListeners();
   }
 
   disconnect() {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix tabs not clickable in dark mode with explicit click listeners
  - Use event.target.closest() for better nested element handling
  - Add pointer-events enforcement and capture phase listeners
  - Extract attachClickListeners() method for maintainability

- Fix signout redirect incompatibility with Turbo Drive
  - Add status: :see_other to SessionsController destroy redirect
  - Ensure logout button breaks out of parent Turbo Frame correctly

- Update DS::MenuItem to handle delete button variants
  - Automatically apply turbo_frame: '_top' for button variant with method: :delete


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dark Mode Tabs Issue"] --> B["Add Explicit Click Listeners"]
  B --> C["Use event.target.closest()"]
  B --> D["Add pointer-events enforcement"]
  B --> E["Use capture phase listeners"]
  F["Signout Redirect Issue"] --> G["Add status: :see_other"]
  H["DS::MenuItem Enhancement"] --> I["Auto turbo_frame for delete buttons"]
  C --> J["Tabs Work Reliably"]
  D --> J
  E --> J
  G --> K["Turbo Drive Compatible"]
  I --> K
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tabs_controller.js</strong><dd><code>Add explicit click listeners for dark mode reliability</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/javascript/controllers/shadcn/tabs_controller.js

<ul><li>Refactored click handling with explicit listeners using capture phase<br> <li> Added attachClickListeners() method to attach/reattach listeners <br>reliably<br> <li> Improved selectTab() with event.target.closest() for nested element <br>handling<br> <li> Added pointer-events: auto enforcement in JavaScript<br> <li> Proper cleanup of listeners in disconnect() method<br> <li> Better fallback handling for edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/35/files#diff-8af2f76a6514e53026ce38033b7fe202d5c4453f2b8b2727401b71e31accacb5">+71/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tabs_component.html.erb</strong><dd><code>Add CSS classes for pointer events and z-index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/shadcn/tabs_component.html.erb

<ul><li>Added relative z-10 class to tab buttons for z-index layering<br> <li> Added pointer-events-auto class to ensure clickability<br> <li> Added inline style pointer-events: auto !important for CSS override</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/35/files#diff-842fd424b63798aaf1836021f872d8afdf5a6467653190bef7571c4ff64cd665">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sessions_controller.rb</strong><dd><code>Add Turbo Drive compatible redirect status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/sessions_controller.rb

<ul><li>Added status: :see_other to redirect_to in destroy action<br> <li> Ensures Turbo Drive correctly processes logout redirect<br> <li> Follows Rails 8.1 best practices for Turbo compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/35/files#diff-cdec550eeeb8fc63be2b5687170f594651a8d0b7f0465c9d807baef392639b6e">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>menu_item.rb</strong><dd><code>Auto apply turbo_frame for delete buttons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/components/DS/menu_item.rb

<ul><li>Extended turbo_frame: '_top' logic to include button variant with <br>method: :delete<br> <li> Ensures logout button breaks out of parent Turbo Frame<br> <li> Maintains existing link variant behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/35/files#diff-ef99dcbc92033128450dc8b27a8b1e761a8229589362b62c8094ba29af82098b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
This pull request introduces several fixes and improvements primarily focused on enhancing the reliability of UI components (tabs) and critical navigation actions (logout), especially in the context of Turbo Frames and dark mode.

Key changes include:

*   **Improved Tabs Component Reliability:**
    *   Ensures tab triggers are consistently clickable by explicitly setting `pointer-events: auto` and `z-index` in the component's HTML and JavaScript.
    *   Enhances the robustness of tab selection by attaching explicit click event listeners in the JavaScript controller, utilizing the capture phase, and accurately identifying the clicked trigger. This addresses potential issues where Stimulus `data-action` might be blocked by CSS layers, particularly in dark mode or with nested elements.
    *   Refines the management of keyboard navigation event listeners for tabs.
*   **Enhanced Logout Functionality:**
    *   Configures logout actions (specifically `button_to` with `method: :delete`) to target the `_top` Turbo Frame. This ensures that logging out always performs a full page navigation, breaking out of any parent Turbo Frames and preventing partial page updates for session-critical actions.
    *   Updates the logout redirect to include `status: :see_other`. This is a Rails 8.1 compatibility change that ensures Turbo Drive correctly handles redirects after a `DELETE` request, facilitating proper full page redirects.
<!-- kody-pr-summary:end -->