### PR TITLE
Potential fix for code scanning alert no. 342: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,5 +1,6 @@
 class WebhooksController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:plaid, :plaid_eu, :stripe]
+  # Matikan CSRF hanya untuk endpoint webhook (bukan seluruh controller)
+  skip_before_action :verify_authenticity_token, only: [ :plaid, :plaid_eu, :stripe ]
   skip_authentication
 
   def plaid
@@ -7,7 +8,6 @@ class WebhooksController < ApplicationController
     plaid_verification_header = request.headers["Plaid-Verification"]
 
     client = Provider::Registry.plaid_provider_for_region(:us)
-
     client.validate_webhook!(plaid_verification_header, webhook_body)
 
     PlaidItem::WebhookProcessor.new(webhook_body).process
@@ -23,7 +23,6 @@ class WebhooksController < ApplicationController
     plaid_verification_header = request.headers["Plaid-Verification"]
 
     client = Provider::Registry.plaid_provider_for_region(:eu)
-
     client.validate_webhook!(plaid_verification_header, webhook_body)
 
     PlaidItem::WebhookProcessor.new(webhook_body).process

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,5 +1,5 @@
 class WebhooksController < ApplicationController
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token, only: [:plaid, :plaid_eu, :stripe]
   skip_authentication
 
   def plaid


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/hendripermana/permoney/security/code-scanning/342](https://github.com/hendripermana/permoney/security/code-scanning/342)

**General fix:**  
Restrict CSRF-protection skipping only to the webhook actions that require it, instead of disabling it for the entire controller. This is achieved by moving `skip_before_action :verify_authenticity_token` from the class level to just the specific actions (`plaid`, `plaid_eu`, `stripe`).

**Best way to fix without changing functionality:**  
Specify the `only` option for `skip_before_action :verify_authenticity_token`, limiting it to the three webhook methods (`:plaid`, `:plaid_eu`, and `:stripe`) within the same controller. This keeps CSRF protection enabled for any other actions (current or future) that may be added.

**Files/regions/lines to change:**  
- In `app/controllers/webhooks_controller.rb`, change line 2:  
  `skip_before_action :verify_authenticity_token`  
  →  
  `skip_before_action :verify_authenticity_token, only: [:plaid, :plaid_eu, :stripe]`

**What is needed:**  
- No new methods, imports, or variable definitions are necessary; simply change the argument to `skip_before_action`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


---

<!-- kody-pr-summary:start -->
Refined the CSRF protection configuration in `WebhooksController`. Previously, CSRF authenticity token verification was entirely skipped for all actions within this controller. This change modifies the `skip_before_action` to apply only to the `plaid`, `plaid_eu`, and `stripe` actions. This re-enables CSRF protection for any other actions in the `WebhooksController`, thereby strengthening security by narrowing the scope of the CSRF bypass.
<!-- kody-pr-summary:end -->


___

### **PR Type**
Bug fix


___

### **Description**
- Restrict CSRF protection bypass to specific webhook actions

- Apply `skip_before_action` only to Plaid and Stripe endpoints

- Re-enable CSRF protection for other controller actions

- Add clarifying comment in Indonesian about CSRF scope


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebhooksController<br/>CSRF disabled globally"] -->|Refactor| B["WebhooksController<br/>CSRF disabled selectively"]
  B --> C["plaid, plaid_eu,<br/>stripe actions<br/>CSRF bypassed"]
  B --> D["Other actions<br/>CSRF protected"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webhooks_controller.rb</strong><dd><code>Restrict CSRF bypass to webhook endpoints only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/webhooks_controller.rb

<ul><li>Modified <code>skip_before_action :verify_authenticity_token</code> to include <br><code>only: [ :plaid, :plaid_eu, :stripe ]</code> parameter<br> <li> Added Indonesian comment explaining CSRF bypass is limited to webhook <br>endpoints<br> <li> Removed unnecessary blank lines for code formatting consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/52/files#diff-5e521bbe24ce600be318f72670142811ce71b614b8419da9feba34a0f7a196a8">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

