### PR TITLE
Fix HTML escaping in PostHog partial

### DIFF
--- a/app/views/shared/_posthog.html.erb
+++ b/app/views/shared/_posthog.html.erb
@@ -1,14 +1,14 @@
 <% if ENV["POSTHOG_API_KEY"].present? %>
   <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init(<%= ENV["POSTHOG_API_KEY"].to_json %>, {
-      api_host: <%= ENV.fetch("POSTHOG_HOST", "https://us.i.posthog.com").to_json %>,
+    posthog.init(<%== ENV["POSTHOG_API_KEY"].to_json %>, {
+      api_host: <%== ENV.fetch("POSTHOG_HOST", "https://us.i.posthog.com").to_json %>,
       person_profiles: 'identified_only'
     })
     <% if defined?(current_user) && current_user %>
       posthog.identify(
-        <%= current_user.id.to_json %>,
-        { email: <%= current_user.email.to_json %>, name: <%= current_user.display_name.to_json %> }
+        <%== current_user.id.to_json %>,
+        { email: <%== current_user.email.to_json %>, name: <%== current_user.display_name.to_json %> }
       );
     <% end %>
   </script>


### PR DESCRIPTION
### **User description**
Fixes a bug where `to_json` output was being HTML escaped by Rails in the PostHog partial, causing invalid JavaScript syntax (e.g. `&quot;` instead of `"`).

Changes:
- Use `<%== ... %>` (raw output) for JSON strings in `app/views/shared/_posthog.html.erb`.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace HTML escaping with raw output in PostHog partial

- Use `<%== ... %>` tags for JSON string interpolation

- Prevent Rails from escaping quotes in JavaScript syntax

- Fix invalid JavaScript caused by HTML entity encoding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rails ERB Template"] -->|"HTML escaping <% %>"| B["Invalid JS: &quot;"]
  A -->|"Raw output <%== %>"| C["Valid JS: &quot;"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_posthog.html.erb</strong><dd><code>Replace HTML escaping with raw output tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/views/shared/_posthog.html.erb

<ul><li>Changed 5 instances of <code><%= ... %></code> to <code><%== ... %></code> for JSON output<br> <li> Affected lines: posthog.init API key, api_host URL, and user <br>identification data<br> <li> Prevents Rails from HTML-escaping JSON strings containing quotes<br> <li> Ensures valid JavaScript syntax in rendered output</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/67/files#diff-d4fd44971dec59adc11813fe9cff4011ce5c77bd3acbcd4d8d87c11e316bb33a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

