### PR TITLE
Implement PostHog Proxy

### DIFF
--- a/app/controllers/posthog_proxy_controller.rb
+++ b/app/controllers/posthog_proxy_controller.rb
@@ -1,0 +1,24 @@
+class PosthogProxyController < ApplicationController
+  skip_authentication
+  skip_before_action :verify_authenticity_token
+
+  def proxy
+    # Construct target URL
+    path = params[:path]
+    path = "#{path}.#{params[:format]}" if params[:format].present?
+    
+    target_url = "https://us.i.posthog.com/#{path}"
+    target_url += "?#{request.query_string}" if request.query_string.present?
+
+    # Forward request using Faraday
+    response = Faraday.new.send(request.method.downcase, target_url) do |req|
+      req.body = request.raw_post if request.post?
+      req.headers['Content-Type'] = request.content_type if request.content_type
+      req.headers['User-Agent'] = request.user_agent
+      req.headers['X-Forwarded-For'] = request.remote_ip
+    end
+
+    # Forward response
+    render body: response.body, status: response.status, content_type: response.headers['content-type']
+  end
+end

--- a/app/views/shared/_posthog.html.erb
+++ b/app/views/shared/_posthog.html.erb
@@ -2,7 +2,8 @@
   <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init(<%== ENV["POSTHOG_API_KEY"].to_json %>, {
-      api_host: <%== ENV.fetch("POSTHOG_HOST", "https://us.i.posthog.com").to_json %>,
+      api_host: "/ingest",
+      ui_host: "https://us.posthog.com",
       person_profiles: 'identified_only'
     })
     <% if defined?(current_user) && current_user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -350,6 +350,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # PostHog Proxy
+  match "/ingest/*path", to: "posthog_proxy#proxy", via: :all
+
   resources :lunchflow_items, only: %i[index new create show edit update destroy] do
     collection do
       get :preload_accounts


### PR DESCRIPTION
### **User description**
Implements a server-side proxy for PostHog events to bypass ad blockers and ensure reliable analytics tracking.

Changes:
- Added `PosthogProxyController` to forward requests to `us.i.posthog.com`.
- Added route `/ingest/*path` to handle PostHog requests.
- Updated `app/views/shared/_posthog.html.erb` to use `/ingest` as the `api_host`.


___

### **PR Type**
Enhancement


___

### **Description**
- Implements server-side PostHog proxy to bypass ad blockers

- Adds `PosthogProxyController` to forward analytics requests

- Routes `/ingest/*path` to proxy PostHog events

- Updates PostHog configuration to use local proxy endpoint


___

### Diagram Walkthrough


```mermaid
flowchart LR
  client["Client Browser"]
  proxy["PostHog Proxy Controller"]
  posthog["us.i.posthog.com"]
  client -- "POST /ingest/*" --> proxy
  proxy -- "Forward Request" --> posthog
  posthog -- "Response" --> proxy
  proxy -- "Return Response" --> client
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>posthog_proxy_controller.rb</strong><dd><code>PostHog proxy controller implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/posthog_proxy_controller.rb

<ul><li>Creates new controller to handle PostHog event forwarding<br> <li> Skips authentication and CSRF verification for proxy requests<br> <li> Constructs target URL to <code>us.i.posthog.com</code> with path and query <br>parameters<br> <li> Uses Faraday to forward HTTP requests with proper headers and body<br> <li> Returns proxied response with original status and content type</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/68/files#diff-090c401989fe626c626198f49a9a99fa7462bc2ab84ccaa8de9fd567e9880487">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_posthog.html.erb</strong><dd><code>Update PostHog configuration to use proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/views/shared/_posthog.html.erb

<ul><li>Changes <code>api_host</code> from environment variable to local proxy path <code>/ingest</code><br> <li> Adds <code>ui_host</code> configuration pointing to PostHog dashboard<br> <li> Enables client-side analytics to use server-side proxy for requests</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/68/files#diff-d4fd44971dec59adc11813fe9cff4011ce5c77bd3acbcd4d8d87c11e316bb33a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.rb</strong><dd><code>Add PostHog proxy route configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/routes.rb

<ul><li>Adds route matching <code>/ingest/*path</code> to <code>posthog_proxy#proxy</code> action<br> <li> Accepts all HTTP methods (GET, POST, etc.) for the proxy endpoint<br> <li> Positioned before lunchflow_items resources</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/68/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

