### PR TITLE
Fix Chat Production Errors: 400 Bad Request & Turbo Frame Issues

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -37,8 +37,14 @@ class ChatsController < ApplicationController
       if @chat&.persisted?
         @chat.add_error(e.message)
       else
-        flash[:alert] = "Failed to start chat: #{e.message}"
-        redirect_to chats_path and return
+        if turbo_frame_request?
+          flash.now[:alert] = "Failed to start chat: #{e.message}"
+          render "chats/floating_new", layout: false, status: :unprocessable_entity
+          return
+        else
+          flash[:alert] = "Failed to start chat: #{e.message}"
+          redirect_to chats_path and return
+        end
       end
     end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -23,7 +23,7 @@ class MessagesController < ApplicationController
     end
 
     def message_params
-      params.require(:message).permit(:content, :ai_model)
+      (params[:message] || params[:user_message]).permit(:content, :ai_model)
     end
 
     def respond_to_success

--- a/app/views/messages/_chat_form.html.erb
+++ b/app/views/messages/_chat_form.html.erb
@@ -13,7 +13,7 @@
     message_record ||= Message.new
     [chat, message_record]
   else
-    Chat.new
+    chat || Chat.new
   end %>
   <% form_options = {
     class: "flex lg:flex-col gap-2 bg-container px-2 py-1.5 rounded-full lg:rounded-lg shadow-border-xs",
@@ -22,19 +22,22 @@
   <% if floating %>
     <% form_options[:url] =
       if chat && chat.persisted?
+        form_options[:scope] = :message
         chat_messages_path(chat, floating: true)
       else
         chats_path(floating: true)
       end %>
   <% elsif chat && chat.persisted? %>
     <% form_options[:url] = chat_messages_path(chat) %>
+    <% form_options[:scope] = :message %>
   <% else %>
     <% form_options[:url] = chats_path %>
   <% end %>
 
-  <% if message_record&.errors&.any? %>
+  <% error_model = model.is_a?(Array) ? model.last : model %>
+  <% if error_model&.errors&.any? %>
     <div class="px-2 py-1">
-      <%= render "shared/form_errors", model: message_record %>
+      <%= render "shared/form_errors", model: error_model %>
     </div>
   <% end %>
 


### PR DESCRIPTION
### **User description**
This PR fixes critical issues causing 400/500 errors in the production chat feature:

1.  **Fix 400 Bad Request on Message Creation**:
    - The `MessagesController` was strictly requiring `params[:message]`.
    - However, because `UserMessage` (an STI subclass of `Message`) is used in the form, Rails `form_with` was generating `params[:user_message]` in some contexts (specifically when re-rendering after a failure or initial load with `@message`).
    - **Fix**: Updated `MessagesController` to accept either `message` or `user_message` params.
    - **Fix**: Updated `_chat_form.html.erb` to explicitly set `scope: :message` when creating a message, ensuring consistent parameter naming.

2.  **Fix "Content Missing" / Floating Chat Closing**:
    - When chat creation failed in the floating window (e.g., API error), `ChatsController` was redirecting to `chats_path`.
    - This redirect caused the Turbo Frame to break or load the full page content (which doesn't match the frame ID), leading to "Content Missing" or the frame closing.
    - **Fix**: Updated `ChatsController#create` to render the `floating_new` view with an error flash message when a Turbo Frame request fails, keeping the user in the floating context and displaying the error.

3.  **Improve Form Error Handling**:
    - Updated `_chat_form.html.erb` to correctly display validation errors for the `Chat` model (not just the message) if chat creation fails.

These changes ensure a robust and error-tolerant chat experience, preventing the UI from breaking even when API or validation errors occur.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Turbo Frame breaking on chat creation failure in floating window

- Render error view instead of redirecting when API fails

- Preserve floating chat context and display error message to user


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chat Creation Fails"] --> B{turbo_frame_request?}
  B -->|Yes| C["Render floating_new with error"]
  B -->|No| D["Redirect to chats_path"]
  C --> E["User stays in floating context"]
  D --> F["Full page navigation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chats_controller.rb</strong><dd><code>Handle Turbo Frame errors in chat creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/chats_controller.rb

<ul><li>Added conditional check for <code>turbo_frame_request?</code> in chat creation <br>error handling<br> <li> Render <code>floating_new</code> view with error flash when Turbo Frame request <br>fails<br> <li> Use <code>flash.now</code> for immediate error display in rendered view<br> <li> Maintain existing redirect behavior for non-Turbo Frame requests</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/75/files#diff-13469cb6cb895850024322d75233f202de90c5f1fc9cc23eaa48ca95751c5c36">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
This pull request fixes chat production errors related to 400 Bad Request responses and Turbo Frame issues. The changes modify the error handling in the chats controller to properly handle Turbo Frame requests.

Specifically, when a chat creation fails, the code now checks if the request is a Turbo Frame request. If it is, it uses `flash.now` and renders the floating new chat form directly without a layout, maintaining the user's context within the Turbo Frame. If it's not a Turbo Frame request, it falls back to the original behavior of setting a regular flash message and redirecting to the chats index page.

This ensures that error messages are properly displayed in both Turbo Frame and regular page contexts, improving the user experience when chat creation fails.
<!-- kody-pr-summary:end -->