### PR TITLE
Link subscriptions with manual transactions and improve Subscription Manager UI

### DIFF
--- a/app/helpers/subscription_plans_helper.rb
+++ b/app/helpers/subscription_plans_helper.rb
@@ -1,22 +1,38 @@
 module SubscriptionPlansHelper
   def subscription_row_class(subscription)
-    return "" unless subscription.present?
+    base = "transition-colors"
+    return base unless subscription.present?
 
     days_until = subscription.days_until_renewal
+
     if days_until.present? && days_until <= 3 && subscription.active?
-      "bg-red-50"
+      # Highlight subscriptions that are due soon while staying theme-aware
+      class_names(base, "bg-orange-50 theme-dark:bg-orange-900/20")
     elsif subscription.paused?
-      "bg-yellow-50"
+      class_names(base, "bg-yellow-50 theme-dark:bg-yellow-900/20")
     elsif subscription.cancelled? || subscription.expired?
-      "bg-gray-50"
+      class_names(base, "bg-gray-50 theme-dark:bg-gray-900/40")
     else
-      ""
+      base
     end
   end
 
+  # Returns the emoji category icon for either a legacy Service or a ServiceMerchant
   def service_icon(service)
     return "📋" unless service.present?
-    service.category_icon || "📋"
+    service.respond_to?(:category_icon) ? service.category_icon : "📋"
+  end
+
+  # Normalized category label for a subscription's service/merchant
+  def subscription_service_category(subscription)
+    service = subscription.service_merchant
+    return nil unless service.present?
+
+    if service.respond_to?(:subscription_category)
+      service.subscription_category
+    else
+      service.respond_to?(:category) ? service.category : nil
+    end
   end
 
   def status_color_class(status)

--- a/app/views/subscription_plans/index.html.erb
+++ b/app/views/subscription_plans/index.html.erb
@@ -149,16 +149,24 @@
           </thead>
           <tbody class="bg-container divide-y divide-gray-200">
             <% @subscription_plans.each do |subscription| %>
-              <tr class="<%= subscription_row_class(subscription) %>">
+              <% service = subscription.service_merchant %>
+              <tr class="hover:bg-surface-hover <%= subscription_row_class(subscription) %>">
                 <td class="px-6 py-4 whitespace-nowrap">
                   <div class="flex items-center">
-                    <span class="text-2xl"><%= service_icon(subscription.service) %></span>
+                    <% if service&.respond_to?(:display_logo_url) && service.display_logo_url.present? %>
+                      <%= image_tag service.display_logo_url, class: "w-8 h-8 rounded-full", loading: "lazy" %>
+                    <% else %>
+                      <span class="text-2xl"><%= service_icon(service) %></span>
+                    <% end %>
                     <div class="ml-4">
                       <div class="text-sm font-medium text-primary"><%= subscription.name %></div>
-                      <div class="text-sm text-secondary"><%= subscription.service&.category&.humanize %></div>
+                      <div class="text-sm text-secondary">
+                        <%= subscription_service_category(subscription)&.humanize || "Subscription" %>
+                      </div>
                       <% if subscription.shared_within_family %>
-                        <div class="text-xs text-blue-600 mt-1 flex items-center gap-1">
-                          <%= icon "users", class: "h-3 w-3" %> Shared
+                        <div class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-blue-50 text-blue-700 theme-dark:bg-blue-900/20 theme-dark:text-blue-200 mt-1">
+                          <%= icon "users", class: "h-3 w-3" %>
+                          <span>Shared</span>
                         </div>
                       <% end %>
                     </div>
@@ -183,7 +191,7 @@
                   <% if subscription.next_billing_at %>
                     <%= subscription.next_billing_at.strftime("%b %d, %Y") %>
                     <% if subscription.days_until_renewal <= 3 && subscription.active? %>
-                      <div class="text-red-600 font-medium mt-1 flex items-center gap-1">
+                      <div class="text-destructive text-sm font-medium mt-1 flex items-center gap-1">
                         <%= icon "alert-triangle", class: "h-3 w-3" %> Renewal due soon
                       </div>
                     <% end %>
@@ -194,33 +202,41 @@
 
                 <td class="px-6 py-4 whitespace-nowrap">
                   <% if subscription.days_until_renewal == 0 %>
-                    <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
+                    <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-800 theme-dark:bg-orange-900/30 theme-dark:text-orange-200">
                       <%= icon "calendar", class: "h-3 w-3" %> Today
                     </span>
                   <% elsif subscription.days_until_renewal <= 3 %>
-                    <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                    <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 theme-dark:bg-red-900/30 theme-dark:text-red-200">
                       <%= icon "alert-triangle", class: "h-3 w-3" %> <%= subscription.days_until_renewal %> days
                     </span>
                   <% else %>
-                    <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                    <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 theme-dark:bg-green-900/30 theme-dark:text-green-200">
                       <%= icon "check-circle", class: "h-3 w-3" %> <%= subscription.days_until_renewal %> days
                     </span>
                   <% end %>
                 </td>
 
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
-                  <%= link_to "View", subscription_plan_path(subscription), class: "text-blue-600 hover:text-blue-900" %>
+                  <%= link_to "View", subscription_plan_path(subscription), class: "text-link hover:text-primary" %>
+                  <%= link_to "Record payment",
+                              new_transaction_path(
+                                account_id: subscription.account_id,
+                                nature: "outflow",
+                                subscription_plan_id: subscription.id
+                              ),
+                              class: "text-link hover:text-primary",
+                              data: { turbo_frame: :modal } %>
                   <% if subscription.active? %>
-                    <%= button_to "Pause", pause_subscription_plan_path(subscription), method: :patch, class: "text-yellow-600 hover:text-yellow-900", form: { class: "inline" } %>
+                    <%= button_to "Pause", pause_subscription_plan_path(subscription), method: :patch, class: "text-yellow-700 hover:text-yellow-900", form: { class: "inline" } %>
                   <% elsif subscription.paused? %>
-                    <%= button_to "Resume", resume_subscription_plan_path(subscription), method: :patch, class: "text-green-600 hover:text-green-900", form: { class: "inline" } %>
+                    <%= button_to "Resume", resume_subscription_plan_path(subscription), method: :patch, class: "text-green-700 hover:text-green-900", form: { class: "inline" } %>
                   <% end %>
                   <% if subscription.cancelled? || subscription.expired? %>
-                    <%= button_to "Delete", subscription_plan_path(subscription), method: :delete, class: "text-red-600 hover:text-red-900", data: { turbo_confirm: "Are you sure you want to delete this subscription?" }, form: { class: "inline" } %>
+                    <%= button_to "Delete", subscription_plan_path(subscription), method: :delete, class: "text-destructive hover:text-red-900", data: { turbo_confirm: "Are you sure you want to delete this subscription?" }, form: { class: "inline" } %>
                   <% else %>
-                    <%= button_to "Cancel", cancel_subscription_plan_path(subscription), method: :patch, class: "text-red-600 hover:text-red-900", form: { class: "inline" } %>
+                    <%= button_to "Cancel", cancel_subscription_plan_path(subscription), method: :patch, class: "text-destructive hover:text-red-900", form: { class: "inline" } %>
                   <% end %>
-                  <%= button_to "Renew", renew_subscription_plan_path(subscription), method: :patch, class: "text-indigo-600 hover:text-indigo-900", form: { class: "inline" } %>
+                  <%= button_to "Renew", renew_subscription_plan_path(subscription), method: :patch, class: "text-link hover:text-primary", form: { class: "inline" } %>
                   <%= link_to "Edit", edit_subscription_plan_path(subscription), class: "text-secondary hover:text-primary" %>
                 </td>
               </tr>

--- a/app/views/subscription_plans/index.html.erb
+++ b/app/views/subscription_plans/index.html.erb
@@ -218,14 +218,21 @@
 
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
                   <%= link_to "View", subscription_plan_path(subscription), class: "text-link hover:text-primary" %>
-                  <%= link_to "Record payment",
-                              new_transaction_path(
-                                account_id: subscription.account_id,
-                                nature: "outflow",
-                                subscription_plan_id: subscription.id
-                              ),
-                              class: "text-link hover:text-primary",
-                              data: { turbo_frame: :modal } %>
+                  <% if subscription.active_or_trial? %>
+                    <%= link_to "Record payment",
+                                new_transaction_path(
+                                  account_id: subscription.account_id,
+                                  nature: "outflow",
+                                  subscription_plan_id: subscription.id
+                                ),
+                                class: "text-link hover:text-primary",
+                                data: {
+                                  turbo_frame: :modal,
+                                  turbo_confirm: "Record payment of #{number_to_currency(subscription.amount, unit: subscription.currency + ' ')} for #{subscription.name}?\n\nThis will advance billing to the next cycle if within payment window."
+                                } %>
+                  <% else %>
+                    <span class="text-gray-400 cursor-not-allowed" title="Subscription is <%= subscription.status %>">Record payment</span>
+                  <% end %>
                   <% if subscription.active? %>
                     <%= button_to "Pause", pause_subscription_plan_path(subscription), method: :patch, class: "text-yellow-700 hover:text-yellow-900", form: { class: "inline" } %>
                   <% elsif subscription.paused? %>

--- a/app/views/subscription_plans/show.html.erb
+++ b/app/views/subscription_plans/show.html.erb
@@ -45,16 +45,25 @@
           <% end %>
         <% end %>
 
-        <%= link_to "Record payment",
-                    new_transaction_path(
-                      account_id: @subscription_plan.account_id,
-                      nature: "outflow",
-                      subscription_plan_id: @subscription_plan.id
-                    ),
-                    class: "inline-flex items-center gap-2 px-4 py-2 border border-secondary rounded-lg text-link hover:bg-surface-hover transition-colors",
-                    data: { turbo_frame: :modal } do %>
-          <%= icon "credit-card", class: "h-4 w-4" %>
-          Record payment
+        <% if @subscription_plan.active_or_trial? %>
+          <%= link_to new_transaction_path(
+                        account_id: @subscription_plan.account_id,
+                        nature: "outflow",
+                        subscription_plan_id: @subscription_plan.id
+                      ),
+                      class: "inline-flex items-center gap-2 px-4 py-2 bg-blue-50 text-blue-700 border border-blue-200 theme-dark:bg-blue-900/20 theme-dark:text-blue-200 theme-dark:border-blue-800 rounded-lg hover:bg-blue-100 transition-colors",
+                      data: {
+                        turbo_frame: :modal,
+                        turbo_confirm: "Record payment of #{number_to_currency(@subscription_plan.amount, unit: @subscription_plan.currency + ' ')} for #{@subscription_plan.name}?\n\nThis will advance billing to the next cycle if within payment window."
+                      } do %>
+            <%= icon "credit-card", class: "h-4 w-4" %>
+            Record payment
+          <% end %>
+        <% else %>
+          <span class="inline-flex items-center gap-2 px-4 py-2 bg-gray-100 text-gray-400 border border-gray-200 rounded-lg cursor-not-allowed theme-dark:bg-gray-800 theme-dark:text-gray-500 theme-dark:border-gray-700" title="Subscription is <%= @subscription_plan.status %>">
+            <%= icon "credit-card", class: "h-4 w-4" %>
+            Record payment
+          </span>
         <% end %>
       </div>
     </div>

--- a/app/views/subscription_plans/show.html.erb
+++ b/app/views/subscription_plans/show.html.erb
@@ -1,5 +1,6 @@
 <div class="container mx-auto px-4 py-6">
   <div class="mb-8">
+    <% service = @subscription_plan.service_merchant %>
     <nav class="flex items-center gap-2 text-sm text-secondary mb-4">
       <%= link_to "Subscriptions", subscription_plans_path, class: "hover:text-primary" %>
       <%= icon "chevron-right", class: "h-4 w-4" %>
@@ -8,10 +9,14 @@
 
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-3">
-        <span class="text-4xl"><%= service_icon(@subscription_plan.service) %></span>
+        <% if service&.respond_to?(:display_logo_url) && service.display_logo_url.present? %>
+          <%= image_tag service.display_logo_url, class: "w-10 h-10 rounded-full", loading: "lazy" %>
+        <% else %>
+          <span class="text-4xl"><%= service_icon(service) %></span>
+        <% end %>
         <div>
           <h1 class="text-2xl font-bold text-primary"><%= @subscription_plan.name %></h1>
-          <p class="text-secondary"><%= @subscription_plan.service&.category&.humanize %></p>
+          <p class="text-secondary"><%= subscription_service_category(@subscription_plan)&.humanize %></p>
         </div>
       </div>
 
@@ -22,22 +27,34 @@
         <% end %>
 
         <% if @subscription_plan.active? %>
-          <%= link_to pause_subscription_plan_path(@subscription_plan), method: :patch, class: "inline-flex items-center gap-2 px-4 py-2 bg-yellow-50 text-yellow-700 border border-yellow-200 rounded-lg hover:bg-yellow-100 transition-colors" do %>
+          <%= link_to pause_subscription_plan_path(@subscription_plan), method: :patch, class: "inline-flex items-center gap-2 px-4 py-2 bg-yellow-50 text-yellow-700 border border-yellow-200 theme-dark:bg-yellow-900/20 theme-dark:text-yellow-200 theme-dark:border-yellow-800 rounded-lg hover:bg-yellow-100 transition-colors" do %>
             <%= icon "pause", class: "h-4 w-4" %>
             Pause
           <% end %>
         <% elsif @subscription_plan.paused? %>
-          <%= link_to resume_subscription_plan_path(@subscription_plan), method: :patch, class: "inline-flex items-center gap-2 px-4 py-2 bg-green-50 text-green-700 border border-green-200 rounded-lg hover:bg-green-100 transition-colors" do %>
+          <%= link_to resume_subscription_plan_path(@subscription_plan), method: :patch, class: "inline-flex items-center gap-2 px-4 py-2 bg-green-50 text-green-700 border border-green-200 theme-dark:bg-green-900/20 theme-dark:text-green-200 theme-dark:border-green-800 rounded-lg hover:bg-green-100 transition-colors" do %>
             <%= icon "play", class: "h-4 w-4" %>
             Resume
           <% end %>
         <% end %>
 
         <% unless @subscription_plan.cancelled? || @subscription_plan.expired? %>
-          <%= link_to cancel_subscription_plan_path(@subscription_plan), method: :patch, data: { confirm: "Are you sure you want to cancel this subscription?" }, class: "inline-flex items-center gap-2 px-4 py-2 bg-red-50 text-red-700 border border-red-200 rounded-lg hover:bg-red-100 transition-colors" do %>
+          <%= link_to cancel_subscription_plan_path(@subscription_plan), method: :patch, data: { confirm: "Are you sure you want to cancel this subscription?" }, class: "inline-flex items-center gap-2 px-4 py-2 bg-red-50 text-red-700 border border-red-200 theme-dark:bg-red-900/30 theme-dark:text-red-300 theme-dark:border-red-800 rounded-lg hover:bg-red-100 transition-colors" do %>
             <%= icon "x-circle", class: "h-4 w-4" %>
             Cancel
           <% end %>
+        <% end %>
+
+        <%= link_to "Record payment",
+                    new_transaction_path(
+                      account_id: @subscription_plan.account_id,
+                      nature: "outflow",
+                      subscription_plan_id: @subscription_plan.id
+                    ),
+                    class: "inline-flex items-center gap-2 px-4 py-2 border border-secondary rounded-lg text-link hover:bg-surface-hover transition-colors",
+                    data: { turbo_frame: :modal } do %>
+          <%= icon "credit-card", class: "h-4 w-4" %>
+          Record payment
         <% end %>
       </div>
     </div>
@@ -95,7 +112,12 @@
           <% if @subscription_plan.shared_within_family %>
             <div>
               <dt class="text-sm text-secondary">Shared</dt>
-              <dd class="mt-1 text-blue-600"><%= icon "users", class: "h-4 w-4 inline" %> Shared with family</dd>
+              <dd class="mt-1">
+                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700 theme-dark:bg-blue-900/20 theme-dark:text-blue-200">
+                  <%= icon "users", class: "h-4 w-4" %>
+                  <span>Shared with family</span>
+                </span>
+              </dd>
             </div>
           <% end %>
 
@@ -199,25 +221,30 @@
       <div class="bg-container rounded-lg border border-primary p-6">
         <h2 class="text-lg font-semibold text-primary mb-4">Service Info</h2>
 
-        <% if @subscription_plan.service %>
+        <% if service %>
           <div class="space-y-3">
             <div>
               <div class="text-sm text-secondary">Service Name</div>
-              <div class="text-primary font-medium"><%= @subscription_plan.service.name %></div>
+              <div class="text-primary font-medium"><%= service.respond_to?(:display_name) ? service.display_name : service.name %></div>
             </div>
 
             <div>
               <div class="text-sm text-secondary">Category</div>
-              <div class="text-primary">
-                <span class="mr-1"><%= @subscription_plan.service.category_icon %></span>
-                <%= @subscription_plan.service.category.humanize %>
+              <div class="text-primary flex items-center gap-1">
+                <span><%= service_icon(service) %></span>
+                <span><%= subscription_service_category(@subscription_plan)&.humanize %></span>
               </div>
             </div>
 
-            <% if @subscription_plan.service.website.present? %>
+            <% website_url = if service.respond_to?(:website_url)
+                                service.website_url
+                              elsif service.respond_to?(:website)
+                                service.website
+                              end %>
+            <% if website_url.present? %>
               <div>
                 <div class="text-sm text-secondary">Website</div>
-                <%= link_to @subscription_plan.service.website, @subscription_plan.service.website, target: "_blank", class: "text-blue-600 hover:underline text-sm" %>
+                <%= link_to website_url, website_url, target: "_blank", class: "text-link hover:underline text-sm" %>
               </div>
             <% end %>
           </div>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -26,8 +26,18 @@
       <% categories = params[:nature] == "inflow" ? income_categories : expense_categories %>
       <%= ef.collection_select :category_id, categories, :id, :name, { prompt: t(".category_prompt"), label: t(".category") } %>
     <% end %>
-    <%= f.date_field :date, label: t(".date"), required: true, min: Entry.min_supported_date, max: Date.current, value: Date.current %>
+    <%= f.date_field :date,
+                     label: t(".date"),
+                     required: true,
+                     min: Entry.min_supported_date,
+                     max: Date.current,
+                     value: (entry.date || Date.current) %>
   </section>
+
+  <%# Preserve subscription context so the controller can link the payment back to the plan %>
+  <% if params[:subscription_plan_id].present? %>
+    <%= hidden_field_tag :subscription_plan_id, params[:subscription_plan_id] %>
+  <% end %>
 
   <%= render DS::Disclosure.new(title: t(".details")) do %>
     <%= f.fields_for :entryable do |ef| %>

--- a/test/system/subscription_plans_test.rb
+++ b/test/system/subscription_plans_test.rb
@@ -1,0 +1,68 @@
+require "application_system_test_case"
+
+class SubscriptionPlansTest < ApplicationSystemTestCase
+  setup do
+    sign_in users(:family_admin)
+  end
+
+  test "record payment from index pre-fills transaction form and advances billing" do
+    subscription = subscription_plans(:spotify_subscription)
+
+    # Make the billing date deterministic for the test
+    billing_date = Date.current
+    subscription.update!(next_billing_at: billing_date)
+    original_usage_count = subscription.usage_count
+
+    visit subscription_plans_path
+
+    within("tr", text: subscription.name) do
+      click_link "Record payment"
+    end
+
+    # Transaction form should open in the modal frame with prefilled values
+    within "turbo-frame#modal" do
+      # Amount and date are prefilled from the subscription
+      formatted_amount = format("%.2f", subscription.amount)
+      assert_field "entry[amount]", with: formatted_amount
+      assert_field "entry[date]", with: billing_date.to_s
+
+      # Subscription context is preserved via hidden field
+      hidden_subscription_field = find("input[name='subscription_plan_id']", visible: :all)
+      assert_equal subscription.id.to_s, hidden_subscription_field.value
+
+      # Account is locked to the subscription account via hidden field
+      hidden_account_field = find("input[name='entry[account_id]']", visible: :all)
+      assert_equal subscription.account_id.to_s, hidden_account_field.value
+
+      # Submit the transaction
+      find("button[type='submit'],input[type='submit']", match: :first).click
+    end
+
+    # After submitting, the subscription's billing date should advance
+    subscription.reload
+    assert_equal billing_date.next_month, subscription.next_billing_at
+    assert_equal original_usage_count + 1, subscription.usage_count
+  end
+
+  test "record payment from show page uses subscription context" do
+    subscription = subscription_plans(:netflix_subscription)
+    billing_date = Date.current
+    subscription.update!(next_billing_at: billing_date)
+
+    visit subscription_plan_path(subscription)
+
+    click_link "Record payment"
+
+    within "turbo-frame#modal" do
+      # The form should carry the subscription_plan_id hidden field
+      hidden_subscription_field = find("input[name='subscription_plan_id']", visible: :all)
+      assert_equal subscription.id.to_s, hidden_subscription_field.value
+
+      # Submitting without changing values should still create a transaction
+      find("button[type='submit'],input[type='submit']", match: :first).click
+    end
+
+    # Ensure at least one entry exists for the subscription account
+    assert subscription.account.entries.exists?
+  end
+end


### PR DESCRIPTION
### **User description**
This PR links the Subscription Manager to the manual transaction flow and refreshes the UI to be service-aware and theme-aware.

## Changes

- **TransactionsController**
  - Add `prefill_entry_from_subscription` to prefill account, currency, amount, date, and merchant when `subscription_plan_id` is present.
  - Hook `link_subscription_payment` into `create` so manual outflow payments that match the subscription's account/currency advance the billing schedule via `record_manual_payment!`.

- **SubscriptionPlan**
  - Add `record_manual_payment!(paid_at:)` to accept manual payments within a small window before `next_billing_at` and call `mark_as_renewed!`.
  - Extend `status_badge_class` with `theme-dark:*` variants for dark mode.

- **Subscription Manager UI**
  - Use `service_merchant` everywhere and show Brandfetch logos when available with emoji fallback via `service_icon`.
  - Add `subscription_service_category` helper so categories render correctly for both `Service` and `ServiceMerchant`.
  - Add "Record payment" actions on index and show pages that open the transaction form in a modal with subscription context.
  - Make row highlights, status badges, "Shared" badges, and "Days Until" chips theme-aware.

- **Transactions form**
  - Make the date field respect `entry.date` so subscription-prefilled dates appear correctly.
  - Add a hidden `subscription_plan_id` field (when present) so the controller can link the payment back to the subscription.

- **Tests**
  - Extend `SubscriptionPlanTest` for `status_badge_class` and the new `record_manual_payment!` behaviour.
  - Add `TransactionsControllerTest` coverage to ensure creating a transaction with `subscription_plan_id` advances `next_billing_at`.

## Validation

- `bin/rubocop` ✅
- `bin/brakeman --no-pager` ✅ (1 existing mass-assignment warning in `SubscriptionPlansController` remains, unchanged)
- `npm run lint` (Biome) ✅
- `bin/rails test` was **not run** in CI here because the local guard detects the test DB pointing at production and there is one pending migration; behaviour is unchanged from `main`. Please run the full Rails test suite in a safe environment once test DB config/migrations are set up.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Link manual transactions to subscription plans and auto-advance billing schedules

- Add "Record payment" actions in Subscription Manager UI with prefilled transaction forms

- Extend theme-aware styling with dark mode support for badges, chips, and highlights

- Normalize service/merchant handling to support both legacy Service and ServiceMerchant models

- Add comprehensive test coverage for subscription payment linking and manual payment recording


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SM["Subscription Manager UI"]
  TF["Transaction Form"]
  TC["TransactionsController"]
  SP["SubscriptionPlan"]
  
  SM -->|"Record payment with subscription_plan_id"| TF
  TF -->|"Submit with subscription context"| TC
  TC -->|"Prefill from subscription"| TF
  TC -->|"Link & record payment"| SP
  SP -->|"Advance billing if within window"| SP
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transactions_controller.rb</strong><dd><code>Link subscriptions to manual transactions with prefill and </code><br><code>auto-advance</code></dd></summary>
<hr>

app/controllers/transactions_controller.rb

<ul><li>Add <code>prefill_entry_from_subscription</code> method to populate account, <br>currency, amount, date, and merchant from subscription plan<br> <li> Implement <code>link_subscription_payment</code> method to record manual payments <br>and advance billing schedule when conditions are met<br> <li> Hook subscription payment linking into transaction creation flow<br> <li> Add subscription plan lookup in <code>new</code> action when <code>subscription_plan_id</code> <br>parameter is present</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/80/files#diff-23dc42489abafcaf676047b62b25243756853f78a1aae264e5998c91f287b9df">+60/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscription_plans_helper.rb</strong><dd><code>Add theme-aware styling and service model normalization</code>&nbsp; &nbsp; </dd></summary>
<hr>

app/helpers/subscription_plans_helper.rb

<ul><li>Update <code>subscription_row_class</code> to add theme-dark variants for row <br>highlighting<br> <li> Enhance <code>service_icon</code> to handle both Service and ServiceMerchant models <br>via <code>respond_to?</code><br> <li> Add <code>subscription_service_category</code> helper to normalize category <br>retrieval from either model type</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/80/files#diff-26d847dc79e8edf71274d3cb96c650c3db47fce30c29efdfd7d56c5a8774e88b">+22/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscription_plan.rb</strong><dd><code>Add dark mode badges and manual payment recording</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/models/subscription_plan.rb

<ul><li>Add dark mode theme variants to <code>status_badge_class</code> for all <br>subscription statuses<br> <li> Implement <code>record_manual_payment!</code> method to accept payments within <br>5-day window before billing date<br> <li> Auto-advance billing schedule via <code>mark_as_renewed!</code> when payment timing <br>is valid</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/80/files#diff-907eb20d88d13aa6e52a315a4c9ec5f25287f3d15623ef0ec4398463bd314920">+27/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html.erb</strong><dd><code>Add record payment action and theme-aware styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/views/subscription_plans/index.html.erb

<ul><li>Replace <code>subscription.service</code> with <code>subscription.service_merchant</code> <br>throughout<br> <li> Add Brandfetch logo display with emoji fallback via <code>service_icon</code> <br>helper<br> <li> Add "Record payment" action link that opens transaction form in modal <br>with subscription context<br> <li> Update row highlighting with hover state and theme-dark variants<br> <li> Apply theme-aware styling to status badges, "Shared" badge, and "Days <br>Until" chips<br> <li> Update action link colors to use semantic tokens like <code>text-link</code> and <br><code>text-destructive</code></ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/80/files#diff-add2386e7976ca3b50e169e93905e2e969a4d6ce425e397e44826b4506d537b4">+31/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show.html.erb</strong><dd><code>Add record payment button and service model normalization</code></dd></summary>
<hr>

app/views/subscription_plans/show.html.erb

<ul><li>Replace <code>subscription.service</code> with <code>subscription.service_merchant</code> for <br>logo and category display<br> <li> Add Brandfetch logo display with emoji fallback<br> <li> Add "Record payment" button that opens transaction form in modal<br> <li> Apply theme-dark variants to pause, resume, and cancel action buttons<br> <li> Update "Shared with family" badge with theme-aware styling<br> <li> Normalize service info display to handle both Service and <br>ServiceMerchant attributes<br> <li> Update link colors to use semantic tokens</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/80/files#diff-4d00ee4709421e9ad34f7529d1cfd4d8259d01e2dde4bde3c7dec627dd51cc84">+40/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_form.html.erb</strong><dd><code>Respect prefilled date and preserve subscription context</code>&nbsp; </dd></summary>
<hr>

app/views/transactions/_form.html.erb

<ul><li>Update date field to respect <code>entry.date</code> so subscription-prefilled <br>dates display correctly<br> <li> Add hidden <code>subscription_plan_id</code> field to preserve subscription context <br>during form submission</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/80/files#diff-5c55e723701fdb319b098bd695babcc104bc99853e23cda4b5e41270ce7276f5">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transactions_controller_test.rb</strong><dd><code>Test subscription payment linking in transactions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/controllers/transactions_controller_test.rb

<ul><li>Add test verifying that creating a transaction with <br><code>subscription_plan_id</code> advances subscription's <code>next_billing_at</code><br> <li> Validate that entry is created with correct attributes and <br>subscription state is updated</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/80/files#diff-d7c2e48bb0711141549f4a1fb32785fc45d870ac2d3bda6a944c6f49a782af42">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>subscription_plan_test.rb</strong><dd><code>Test manual payment recording and dark mode badges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/models/subscription_plan_test.rb

<ul><li>Update existing badge class tests to expect dark mode theme variants<br> <li> Add test for <code>record_manual_payment</code> advancing billing when payment is <br>near billing date<br> <li> Add test for <code>record_manual_payment</code> ignoring payments far from billing <br>date</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/80/files#diff-9b622ea59544bc218fc466d38f55da5f887800b84832a293cde4b10d51dfa630">+24/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
This pull request enhances the Subscription Manager by linking manual transactions to subscription plans and improving the UI. The changes include:

**Core Functionality:**
- Added ability to record manual payments for subscriptions directly from the subscription list and detail pages
- When creating a transaction from a subscription, the form is pre-filled with subscription details (account, amount, currency, date, merchant)
- Manual payments are automatically linked to the corresponding subscription and advance the billing schedule when appropriate

**UI Improvements:**
- Enhanced subscription table with better visual hierarchy, improved status badges with dark theme support, and a new "Record payment" action button
- Added service logos when available, with fallback to category icons
- Improved color coding for subscription status (due soon, paused, cancelled/expired) with theme-aware styling
- Better responsive design and consistent button styling across the subscription views

**Technical Changes:**
- Added `record_manual_payment!` method to SubscriptionPlan model to handle manual payment linking
- Enhanced form handling in TransactionsController to preserve subscription context
- Improved helper methods for service categorization and icon display
- Added proper error handling and logging for subscription payment linking

The implementation maintains loose coupling between transactions and subscriptions while ensuring manual payments keep subscription renewals in sync with real-world payments.
<!-- kody-pr-summary:end -->