### PR TITLE
Improve service dropdown to show all services with pagination

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -12,11 +12,19 @@ class ServicesController < ApplicationController
         @custom_services = ServiceMerchant.where(popular: false).order(:name)
       end
       format.turbo_stream do
-        # Combobox search endpoint - return services matching search query
-        @services = ServiceMerchant
+        # Combobox search endpoint - return services matching search query with pagination
+        per_page = 50
+        page = (params[:page] || 1).to_i
+
+        base_query = ServiceMerchant
           .search(params[:q])
           .order(Arel.sql("CASE WHEN popular = true THEN 0 ELSE 1 END"), :name)
-          .limit(20)
+
+        total_count = base_query.count
+        @services = base_query.offset((page - 1) * per_page).limit(per_page)
+
+        # Calculate if there's a next page
+        @next_page = (page * per_page < total_count) ? page + 1 : nil
       end
     end
   end

--- a/app/views/services/index.turbo_stream.erb
+++ b/app/views/services/index.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= async_combobox_options @services.map(&:to_combobox_option),
-    render_in: { partial: "services/combobox_service" } %>
+    render_in: { partial: "services/combobox_service" },
+    next_page: @next_page %>


### PR DESCRIPTION
### **User description**
## Summary

Fixes the issue where the service dropdown in subscription form only showed limited services when scrolling. Now all services are displayed with proper pagination support.

## Changes

- Added pagination support to service combobox endpoint (50 items per page)
- Implemented `next_page` parameter for hotwire_combobox infinite scroll
- Services load automatically in batches as user scrolls down
- Popular services always shown first, then custom services alphabetically

## Before
- Only 20 services shown when scrolling
- User had to type to search for services not in initial list

## After
- All services visible by scrolling
- Automatic pagination loads more services as needed
- Search still works for quick filtering

## Testing
- [x] Rubocop passed
- [x] ERB lint passed


___

### **PR Type**
Enhancement


___

### **Description**
- Add pagination support to service combobox endpoint

- Services load in batches (50 per page) as user scrolls

- Popular services prioritized first, then custom services

- Fixes issue where only limited services were visible


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Service Index Request"] --> B["Calculate Page & Offset"]
  B --> C["Query Services with Pagination"]
  C --> D["Determine Next Page"]
  D --> E["Return Services + Next Page"]
  E --> F["Combobox Renders with Infinite Scroll"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services_controller.rb</strong><dd><code>Implement pagination in service combobox endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/controllers/services_controller.rb

<ul><li>Added pagination logic with 50 items per page<br> <li> Extract page parameter from request (defaults to 1)<br> <li> Calculate total count and determine if next page exists<br> <li> Changed limit from 20 to dynamic pagination with offset</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/82/files#diff-b572b067d0b1de6e05a13bedd00eb16f20ed91acaadf5d58dc90f88c99961fc0">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.turbo_stream.erb</strong><dd><code>Enable infinite scroll in combobox view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/views/services/index.turbo_stream.erb

<ul><li>Pass <code>next_page</code> parameter to async_combobox_options<br> <li> Enables hotwire combobox infinite scroll functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/82/files#diff-7de43da7fab5108b27feff06039067d0c23e6bfbfe7acde88746b1a3d1875188">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
This pull request improves the service dropdown functionality by implementing pagination to handle large numbers of services. The changes include:

- Modified the services controller to implement pagination with 50 services per page instead of limiting to 20 results
- Added logic to calculate total count and determine if additional pages exist
- Updated the turbo stream view to pass the next page information to the combobox component
- This allows users to load more services as they scroll through the dropdown, improving performance while ensuring all services remain accessible

The implementation maintains the existing popular services ordering while providing a better user experience for browsing large service lists.
<!-- kody-pr-summary:end -->