### PR TITLE
Fix service avg_monthly_cost currency display

### DIFF
--- a/app/models/service_merchant/combobox_option.rb
+++ b/app/models/service_merchant/combobox_option.rb
@@ -1,7 +1,7 @@
 class ServiceMerchant::ComboboxOption
   include ActiveModel::Model
 
-  attr_accessor :id, :name, :logo_url, :category, :billing_frequency, :avg_monthly_cost
+  attr_accessor :id, :name, :logo_url, :category, :billing_frequency, :avg_monthly_cost, :formatted_cost
 
   def to_combobox_display
     name

--- a/app/views/services/_combobox_service.turbo_stream.erb
+++ b/app/views/services/_combobox_service.turbo_stream.erb
@@ -10,8 +10,8 @@
     <span class="text-sm font-medium text-primary truncate"><%= combobox_service.name %></span>
     <span class="text-xs text-secondary">
       <%= combobox_service.category&.humanize || "Other" %>
-      <% if combobox_service.avg_monthly_cost.present? && combobox_service.avg_monthly_cost > 0 %>
-        &middot; ~<%= number_to_currency(combobox_service.avg_monthly_cost) %>/mo
+      <% if combobox_service.formatted_cost.present? %>
+        &middot; ~<%= combobox_service.formatted_cost %>/mo
       <% end %>
     </span>
   </div>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -57,7 +57,7 @@
                       </td>
                       <td class="py-3 px-4 text-sm text-secondary">
                         <% if service.avg_monthly_cost.present? && service.avg_monthly_cost > 0 %>
-                          ~<%= number_to_currency(service.avg_monthly_cost) %>/mo
+                          ~<%= service.formatted_avg_monthly_cost %>/mo
                         <% end %>
                       </td>
                       <td class="py-3 px-4 text-sm">


### PR DESCRIPTION
### **User description**
## Summary
Fix service average monthly cost to display in user's preferred currency instead of always showing USD.

## Problem
1. **Popular services**: Seeded with USD prices (Netflix $15.99, etc.) but displayed without currency conversion
2. **Custom services**: Users entered prices but they showed with USD symbol regardless of user's currency preference

## Solution
Implemented currency-aware formatting using existing `Money` and `ExchangeRate` system:

### New Methods in `ServiceMerchant`
- `avg_cost_currency` - Returns source currency (USD for popular, family currency for custom)
- `avg_monthly_cost_money` - Returns Money object with proper currency
- `avg_monthly_cost_in(target_currency)` - Converts cost to target currency using ExchangeRate
- `formatted_avg_monthly_cost` - Pre-formatted string in user's currency

### Logic
- **Popular services** (seeded, `popular: true`): Prices stored in USD, converted to user's family currency
- **Custom services** (user created, `popular: false`): Assumed to be in user's family currency, displayed with proper currency symbol

### Example
- User currency: IDR (Indonesian Rupiah)
- Netflix (popular): `$15.99` → converted → `Rp252.500` (based on exchange rate)
- Custom "ChatGPT Plus" (custom): User entered `320000` → displays as `Rp320.000`

## Files Changed
- `app/models/service_merchant.rb` - Added currency conversion methods
- `app/models/service_merchant/combobox_option.rb` - Added `formatted_cost` attribute
- `app/views/services/_combobox_service.turbo_stream.erb` - Use pre-formatted cost
- `app/views/services/index.html.erb` - Use new formatting method

## Technical Details
- Uses existing `Money` class with `exchange_to` method
- Leverages `ExchangeRate` table for currency conversion
- Fallback rate of 1.0 if exchange rate not available
- Pre-calculates formatted cost in ComboboxOption to avoid N+1 queries

## Testing
- [x] RuboCop passed
- [x] ERB Lint passed
- [x] Brakeman security scan (no new issues)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implement currency-aware formatting for service costs

- Popular services converted from USD to user's family currency

- Custom services displayed in user's family currency

- Add Money object methods for cost conversion and formatting

- Pre-calculate formatted costs in ComboboxOption for performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Service Cost<br/>Popular/Custom"] --> B["avg_cost_currency<br/>USD or Family"]
  B --> C["avg_monthly_cost_money<br/>Money Object"]
  C --> D["avg_monthly_cost_in<br/>Convert Currency"]
  D --> E["formatted_avg_monthly_cost<br/>Formatted String"]
  E --> F["Display in Views<br/>User's Currency"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_merchant.rb</strong><dd><code>Add currency conversion methods to ServiceMerchant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/models/service_merchant.rb

<ul><li>Add <code>avg_cost_currency</code> method to determine source currency (USD for <br>popular, family currency for custom)<br> <li> Add <code>avg_monthly_cost_money</code> method returning Money object with proper <br>currency<br> <li> Add <code>avg_monthly_cost_in</code> method for currency conversion using <br>ExchangeRate system with fallback rate<br> <li> Add <code>formatted_avg_monthly_cost</code> method for pre-formatted cost string in <br>target currency<br> <li> Update <code>to_combobox_option</code> to include <code>formatted_cost</code> attribute</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/84/files#diff-c5a923b0a1bd419293ed8fd4d8548c927e1e0c3991289e1d2470d46004aadc3d">+39/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>combobox_option.rb</strong><dd><code>Add formatted_cost attribute to ComboboxOption</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/models/service_merchant/combobox_option.rb

<ul><li>Add <code>formatted_cost</code> attribute to store pre-calculated formatted cost <br>string<br> <li> Enables efficient cost display without N+1 queries in views</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/84/files#diff-aeaa7af756fd707ab6fcaec9fc659ccec0ddc129284297be38b78e49d52fc46f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_combobox_service.turbo_stream.erb</strong><dd><code>Use pre-formatted cost in combobox display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/views/services/_combobox_service.turbo_stream.erb

<ul><li>Replace <code>number_to_currency</code> with pre-formatted <code>formatted_cost</code> from <br>ComboboxOption<br> <li> Update conditional to check for <code>formatted_cost</code> presence instead of <br>numeric value<br> <li> Improves performance by using pre-calculated formatted string</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/84/files#diff-dfadc9bae61beeccd10ad1d79cf4ebf9058c8de6d3187f587f323e772501ef9c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html.erb</strong><dd><code>Display service costs in user's currency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/views/services/index.html.erb

<ul><li>Replace <code>number_to_currency</code> with <code>formatted_avg_monthly_cost</code> method call<br> <li> Displays service costs in user's preferred currency instead of default <br>USD<br> <li> Maintains same conditional check for cost presence and value</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/84/files#diff-f02112040a6e7bfd2f0cd5399cc4a01fe2e99fdb878019aceb3101d6449bbb76">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
This pull request fixes the currency display for service average monthly costs in the application. The changes implement proper currency handling and formatting for service costs throughout the UI.

**Key changes:**

1. **Enhanced ServiceMerchant model** (`app/models/service_merchant.rb`):
   - Added `formatted_cost` field to combobox options
   - Implemented currency-aware cost methods:
     - `avg_cost_currency()` - determines source currency (USD for popular services, family currency for custom services)
     - `avg_monthly_cost_in()` - converts costs to target currency using ExchangeRate system
     - `formatted_avg_monthly_cost()` - returns properly formatted currency display

2. **Updated ComboboxOption model** (`app/models/service_merchant/combobox_option.rb`):
   - Added `formatted_cost` attribute to store pre-formatted currency display

3. **Fixed UI components**:
   - **Combobox template** (`app/views/services/_combobox_service.turbo_stream.erb`): Now displays `formatted_cost` instead of raw numeric cost
   - **Services index page** (`app/views/services/index.html.erb`): Uses `formatted_avg_monthly_cost` for proper currency display

**Functional impact:**
- Service costs now display in the user's family currency instead of always showing USD
- Popular services (seeded with USD prices) are properly converted to the user's currency
- Custom services display in the user's configured family currency
- Currency formatting is consistent across all service listings and selection components
<!-- kody-pr-summary:end -->