### PR TITLE
Fix connection_pool keyword compatibility for Redis cache

### DIFF
--- a/config/initializers/connection_pool_backcompat.rb
+++ b/config/initializers/connection_pool_backcompat.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Backward compatibility: Rails 8.1 Redis cache store calls ConnectionPool.new
+# with a positional hash. connection_pool 3.x expects keyword args only.
+# This wrapper converts a single hash arg into keyword args to avoid
+# "wrong number of arguments" crashes at boot.
+if defined?(ConnectionPool)
+  class ConnectionPool
+    alias_method :__permoney_orig_initialize, :initialize
+
+    def initialize(*args, **kwargs, &block)
+      if args.first.is_a?(Hash) && kwargs.empty?
+        kwargs = args.shift.transform_keys { |k| k.respond_to?(:to_sym) ? k.to_sym : k }
+      end
+
+      __permoney_orig_initialize(**kwargs, &block)
+    end
+  end
+end


### PR DESCRIPTION
### **User description**
## Summary
- add backcompat initializer so Rails 8.1 Redis cache store works with connection_pool 3.x keyword-only initializer
- prevents worker boot crash (`wrong number of arguments` in ConnectionPool.new)

## Testing
- not run here (prod container fix); change is isolated to initializer


___

### **PR Type**
Bug fix


___

### **Description**
- Add backward compatibility layer for Rails 8.1 Redis cache store

- Convert positional hash arguments to keyword arguments for connection_pool 3.x

- Prevent "wrong number of arguments" crashes during worker boot


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rails 8.1 Redis<br/>Cache Store"] -- "calls with<br/>positional hash" --> B["ConnectionPool<br/>Wrapper"]
  B -- "converts to<br/>keyword args" --> C["ConnectionPool 3.x<br/>initialize"]
  C -- "successful<br/>initialization" --> D["Worker Boot<br/>Success"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connection_pool_backcompat.rb</strong><dd><code>Add ConnectionPool initialize compatibility wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/initializers/connection_pool_backcompat.rb

<ul><li>Create new initializer file with ConnectionPool monkey patch<br> <li> Override <code>initialize</code> method to accept both positional hash and keyword <br>arguments<br> <li> Transform positional hash argument keys to symbols and convert to <br>keyword arguments<br> <li> Delegate to original initialize with converted keyword arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/87/files#diff-f41c2daececcf2a50830b705bfaea22969865a437e5e3f6c00295308bcf3809c">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
This pull request adds a backward compatibility shim to fix Redis cache initialization crashes in Rails 8.1. The issue occurs because Rails 8.1 passes connection pool configuration as a positional hash argument, while connection_pool 3.x expects keyword arguments. The fix wraps ConnectionPool's initialize method to automatically convert a single hash argument into keyword arguments, preventing "wrong number of arguments" errors during application boot.
<!-- kody-pr-summary:end -->