### PR TITLE
Patch connection_pool init early during boot

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -5,3 +5,27 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+
+# Backward compatibility for connection_pool 3.x (keyword-only initializer)
+# Rails 8.1 Redis cache store may call ConnectionPool.new with a single hash.
+# Patch early, before environments configure cache_store.
+begin
+  require "connection_pool"
+
+  class ConnectionPool
+    unless method_defined?(:__permoney_orig_initialize)
+      alias_method :__permoney_orig_initialize, :initialize
+
+      def initialize(*args, **kwargs, &block)
+        if args.first.is_a?(Hash) && kwargs.empty?
+          kwargs = args.shift.transform_keys { |k| k.respond_to?(:to_sym) ? k.to_sym : k }
+        end
+
+        __permoney_orig_initialize(**kwargs, &block)
+      end
+    end
+  end
+rescue LoadError
+  # connection_pool not available yet; cache_store config will fail similarly,
+  # but we avoid breaking boot in environments that don't use Redis.
+end


### PR DESCRIPTION
### **User description**
## Summary
- patch `ConnectionPool#initialize` early in `config/boot.rb` to accept a single hash argument, fixing Redis cache store boot on connection_pool 3.x (avoids `wrong number of arguments` during environment load)
- no other code changes

## Testing
- not run here (change is boot-time patch to stop crash in containers)


___

### **PR Type**
Bug fix


___

### **Description**
- Patch `ConnectionPool#initialize` early in `config/boot.rb` for compatibility

- Convert single hash argument to keyword arguments for connection_pool 3.x

- Prevents `wrong number of arguments` error during Redis cache store initialization

- Gracefully handles environments without Redis via LoadError rescue


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["config/boot.rb"] -->|"Require connection_pool"| B["Patch ConnectionPool class"]
  B -->|"Alias original initialize"| C["New initialize method"]
  C -->|"Convert hash to kwargs"| D["Call original with kwargs"]
  D -->|"Success"| E["Boot completes"]
  B -->|"LoadError"| F["Skip patch gracefully"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>boot.rb</strong><dd><code>Add ConnectionPool initializer compatibility patch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/boot.rb

<ul><li>Added early boot-time patch for <code>ConnectionPool#initialize</code> to handle <br>connection_pool 3.x keyword-only initializer<br> <li> Converts single hash argument to keyword arguments before calling <br>original initializer<br> <li> Wraps patch in begin/rescue block to gracefully handle missing <br>connection_pool gem<br> <li> Patch applied before environment configuration to prevent cache_store <br>initialization failures</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/88/files#diff-441bbd2acf3b2eab84a98d917f574109eafd6c54cbce74a2379487f9f67920a2">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
This pull request patches the ConnectionPool initialization to maintain backward compatibility with connection_pool 3.x during Rails boot. The issue occurs when Rails 8.1's Redis cache store calls ConnectionPool.new with a single hash argument, which is incompatible with connection_pool 3.x's keyword-only initializer.

The fix adds a patch in config/boot.rb that:
- Wraps the original initialize method
- Detects when a hash is passed as the first positional argument
- Transforms the hash keys to symbols and passes them as keyword arguments
- Ensures the application can boot successfully even when using connection_pool 3.x

This allows the application to maintain compatibility with both older and newer versions of the connection_pool gem without breaking the boot process.
<!-- kody-pr-summary:end -->