### PR TITLE
Guard connection_pool patch to prevent recursion

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -12,8 +12,10 @@ require "bootsnap/setup" # Speed up boot time by caching expensive operations.
 begin
   require "connection_pool"
 
-  class ConnectionPool
-    unless method_defined?(:__permoney_orig_initialize)
+  unless ConnectionPool.instance_variable_defined?(:@__permoney_patched)
+    ConnectionPool.instance_variable_set(:@__permoney_patched, true)
+
+    ConnectionPool.class_eval do
       alias_method :__permoney_orig_initialize, :initialize
 
       def initialize(*args, **kwargs, &block)


### PR DESCRIPTION
### **User description**
## Summary
- add a one-time guard around the connection_pool initializer shim in `config/boot.rb`
- prevent re-aliasing the initializer during boot so the patch cannot recurse and overflow
- keep hash-to-keyword conversion for Rails 8.1 cache-store calls

## Testing
- bundle exec ruby -e "require './config/boot'; require 'connection_pool'; ConnectionPool.new(size:1) { Object.new }; puts 'ok'"


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add early connection_pool initialization patch during boot

- Guard patch with instance variable to prevent recursion

- Convert hash arguments to keyword arguments for Rails 8.1 compatibility

- Handle LoadError gracefully for environments without Redis


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Boot process"] --> B["Require connection_pool"]
  B --> C["Check @__permoney_patched guard"]
  C --> D["Patch initialize method"]
  D --> E["Convert hash to kwargs"]
  E --> F["Call original initialize"]
  C --> G["Skip if already patched"]
  B --> H["Handle LoadError"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>boot.rb</strong><dd><code>Add guarded connection_pool initialization patch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/boot.rb

<ul><li>Add early connection_pool require and patching logic during boot<br> <li> Implement guard using instance variable to prevent re-aliasing<br> <li> Convert hash arguments to keyword arguments for Rails 8.1 <br>compatibility<br> <li> Wrap in begin/rescue to handle missing connection_pool gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/89/files#diff-441bbd2acf3b2eab84a98d917f574109eafd6c54cbce74a2379487f9f67920a2">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
Guard connection_pool patch to prevent recursion

This pull request adds a guard to prevent the connection_pool patch from being applied multiple times. The patch modifies the ConnectionPool class to handle both positional and keyword arguments for backward compatibility with connection_pool 3.x, but without a guard it could cause recursion issues if applied repeatedly during application boot.

The changes include:
- Adding a class-level instance variable `@__permoney_patched` to track whether the patch has already been applied
- Wrapping the patch logic in a conditional check to only apply it once
- This prevents potential recursion or stack overflow issues that could occur if the alias_method calls were executed multiple times
<!-- kody-pr-summary:end -->