### PR TITLE
fix(ui): Resolve menu button regression after transaction creation in Rails 8.1

### DIFF
--- a/app/javascript/controllers/DS/menu_controller.js
+++ b/app/javascript/controllers/DS/menu_controller.js
@@ -9,6 +9,7 @@ import { Controller } from "@hotwired/stimulus";
  * - Moves content to body to avoid overflow:hidden clipping issues
  * - Dispatches custom event to close other open menus (prevents stacking)
  * - Stores direct element references since targets are lost when moved to body
+ * - Rails 8.1: Properly handles Turbo morph refreshes by cleaning up orphaned content
  */
 export default class extends Controller {
   static targets = ["button", "content"];
@@ -20,6 +21,9 @@ export default class extends Controller {
   };
 
   connect() {
+    // Generate unique ID for this menu instance to track its content
+    this._menuId = `ds-menu-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
     // Store direct references before moving to body (targets won't work after move)
     this._buttonEl = this.hasButtonTarget ? this.buttonTarget : null;
     this._contentEl = this.hasContentTarget ? this.contentTarget : null;
@@ -28,6 +32,9 @@ export default class extends Controller {
       console.warn("DS--menu: Missing button or content target");
       return;
     }
+
+    // Mark content with unique ID for cleanup tracking
+    this._contentEl.setAttribute("data-ds-menu-id", this._menuId);
 
     this.show = this.showValue;
     this.boundUpdate = this.update.bind(this);
@@ -61,16 +68,33 @@ export default class extends Controller {
   }
 
   // Restore content to original position when cleaning up
+  // Rails 8.1: With Turbo morph refreshes, the original parent may be morphed/replaced,
+  // so we need to remove orphaned content from body to prevent accumulation
   removeContentFromBody() {
-    if (this._contentEl && this._originalParent && document.body.contains(this._contentEl)) {
+    if (this._contentEl && document.body.contains(this._contentEl)) {
       try {
-        if (this._originalNextSibling && this._originalParent.contains(this._originalNextSibling)) {
-          this._originalParent.insertBefore(this._contentEl, this._originalNextSibling);
-        } else if (document.contains(this._originalParent)) {
-          this._originalParent.appendChild(this._contentEl);
+        // Try to restore to original position first
+        if (this._originalParent && document.contains(this._originalParent)) {
+          if (
+            this._originalNextSibling &&
+            this._originalParent.contains(this._originalNextSibling)
+          ) {
+            this._originalParent.insertBefore(this._contentEl, this._originalNextSibling);
+          } else {
+            this._originalParent.appendChild(this._contentEl);
+          }
+        } else {
+          // Original parent no longer in DOM (Turbo morph replaced it)
+          // Remove the orphaned content element to prevent accumulation
+          this._contentEl.remove();
         }
       } catch {
-        // Parent may have been removed from DOM during Turbo navigation
+        // Failsafe: remove content if any error occurs during restoration
+        try {
+          this._contentEl.remove();
+        } catch {
+          // Content already removed or inaccessible
+        }
       }
     }
     this._originalParent = null;
@@ -85,6 +109,7 @@ export default class extends Controller {
     this.outsideClickHandler = this.handleOutsideClick.bind(this);
     this.turboLoadHandler = this.handleTurboLoad.bind(this);
     this.turboBeforeVisitHandler = this.handleTurboBeforeVisit.bind(this);
+    this.turboBeforeRenderHandler = this.handleTurboBeforeRender.bind(this);
     this.closeOtherMenusHandler = this.handleCloseOtherMenus.bind(this);
 
     this._buttonEl.addEventListener("click", this.toggleHandler);
@@ -92,6 +117,7 @@ export default class extends Controller {
     document.addEventListener("click", this.outsideClickHandler);
     document.addEventListener("turbo:load", this.turboLoadHandler);
     document.addEventListener("turbo:before-visit", this.turboBeforeVisitHandler);
+    document.addEventListener("turbo:before-render", this.turboBeforeRenderHandler);
     document.addEventListener("ds:menu:close-others", this.closeOtherMenusHandler);
   }
 
@@ -111,6 +137,9 @@ export default class extends Controller {
     if (this.turboBeforeVisitHandler) {
       document.removeEventListener("turbo:before-visit", this.turboBeforeVisitHandler);
     }
+    if (this.turboBeforeRenderHandler) {
+      document.removeEventListener("turbo:before-render", this.turboBeforeRenderHandler);
+    }
     if (this.closeOtherMenusHandler) {
       document.removeEventListener("ds:menu:close-others", this.closeOtherMenusHandler);
     }
@@ -122,6 +151,14 @@ export default class extends Controller {
 
   handleTurboBeforeVisit() {
     this.close();
+  }
+
+  // Rails 8.1: Handle Turbo morph refreshes - cleanup content before render
+  handleTurboBeforeRender() {
+    this.close();
+    // Proactively remove content from body before Turbo morphs the page
+    // This prevents orphaned content accumulation with morph refreshes
+    this.removeContentFromBody();
   }
 
   handleCloseOtherMenus(event) {

--- a/app/javascript/controllers/DS/menu_controller.js
+++ b/app/javascript/controllers/DS/menu_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
 
   connect() {
     // Generate unique ID for this menu instance to track its content
-    this._menuId = `ds-menu-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    this._menuId = `ds-menu-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
     // Store direct references before moving to body (targets won't work after move)
     this._buttonEl = this.hasButtonTarget ? this.buttonTarget : null;
@@ -74,7 +74,8 @@ export default class extends Controller {
     if (this._contentEl && document.body.contains(this._contentEl)) {
       try {
         // Try to restore to original position first
-        if (this._originalParent && document.contains(this._originalParent)) {
+        // Use isConnected with optional chaining for cleaner DOM existence check
+        if (this._originalParent?.isConnected) {
           if (
             this._originalNextSibling &&
             this._originalParent.contains(this._originalNextSibling)
@@ -90,11 +91,8 @@ export default class extends Controller {
         }
       } catch {
         // Failsafe: remove content if any error occurs during restoration
-        try {
-          this._contentEl.remove();
-        } catch {
-          // Content already removed or inaccessible
-        }
+        // Element.remove() is safe and won't throw even if already removed
+        this._contentEl.remove();
       }
     }
     this._originalParent = null;


### PR DESCRIPTION
### **User description**
## Summary

Fixes the "New" button on account pages becoming unresponsive after adding a transaction. This is a regression introduced after upgrading to Rails 8.1.

## Problem

After creating a transaction from an individual bank account page, the "New" dropdown menu button stopped working. Users had to reload the page to add another transaction. The global Transactions page was not affected.

## Root Cause

The `DS::Menu` Stimulus controller moves dropdown content to `document.body` to avoid overflow clipping. With Rails 8.1's `turbo_refreshes_with method: :morph` enabled:

1. After transaction creation, Turbo Stream redirects back to the account page
2. Turbo morphs the page instead of replacing it
3. The old menu content in `body` became orphaned (original parent was morphed/replaced)
4. The controller's `removeContentFromBody()` couldn't restore content to a parent that no longer exists
5. Orphaned content accumulated, interfering with new menu instances

## Solution

- Added `turbo:before-render` event handler to proactively cleanup content before Turbo morph renders
- Updated `removeContentFromBody()` to actually remove orphaned elements from body when the original parent is no longer in the DOM
- Added unique ID tracking for menu instances for better debugging

## Testing

- Verified JavaScript linting passes (`npm run lint`)
- Manual testing required: Navigate to account page → Add transaction → Verify "New" button still works

## Files Changed

- `app/javascript/controllers/DS/menu_controller.js`


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes "New" button becoming unresponsive after transaction creation in Rails 8.1

- Adds `turbo:before-render` event handler to cleanup orphaned menu content

- Improves `removeContentFromBody()` to remove orphaned elements when parent is morphed

- Adds unique ID tracking for menu instances for better debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Transaction Created"] -->|"Turbo Stream Redirect"| B["Page Morph Refresh"]
  B -->|"Old Implementation"| C["Orphaned Content in Body"]
  C -->|"Accumulation"| D["Menu Malfunction"]
  B -->|"New Implementation"| E["turbo:before-render Handler"]
  E -->|"Cleanup Content"| F["Remove Orphaned Elements"]
  F -->|"Result"| G["Menu Works Correctly"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>menu_controller.js</strong><dd><code>Add Turbo morph cleanup and orphaned content removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/javascript/controllers/DS/menu_controller.js

<ul><li>Added unique ID generation (<code>_menuId</code>) for each menu instance to track <br>content<br> <li> Added <code>turbo:before-render</code> event listener to proactively cleanup <br>content before Turbo morph renders<br> <li> Enhanced <code>removeContentFromBody()</code> to remove orphaned elements when <br>original parent is no longer in DOM<br> <li> Added failsafe error handling to ensure content removal even if <br>restoration fails<br> <li> Updated JSDoc comments to document Rails 8.1 Turbo morph handling</ul>


</details>


  </td>
  <td><a href="https://github.com/hendripermana/permoney/pull/94/files#diff-1cadf7adfc84c2d63af0696ec2707577516ce77a7fad70a29e231b7ee5f10050">+43/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



---

<!-- kody-pr-summary:start -->
This pull request fixes a menu button regression that occurred after transaction creation in Rails 8.1. The issue was caused by Turbo morph refreshes accumulating orphaned menu content in the body, which prevented menu buttons from working properly.

The fix implements proper cleanup handling for Turbo morph refreshes by:

- Adding a unique ID system to track menu instances and their content
- Modifying the cleanup logic to remove orphaned content from the body when the original parent is no longer in the DOM (which happens during Turbo morphs)
- Adding a new event listener for `turbo:before-render` to proactively clean up content before page morphs occur
- Enhancing error handling to ensure content is removed even if restoration to original position fails

These changes ensure that menu buttons continue to function correctly after transaction creation and other Turbo morph operations, preventing the accumulation of orphaned DOM elements that would break subsequent menu interactions.
<!-- kody-pr-summary:end -->