### PR TITLE
Restore test suite compatibility

### DIFF
--- a/test/controllers/plaid_items_controller_test.rb
+++ b/test/controllers/plaid_items_controller_test.rb
@@ -4,6 +4,7 @@ require "ostruct"
 class PlaidItemsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in @user = users(:family_admin)
+    Setting.stubs(:plaid_enabled).returns(true)
   end
 
   test "create" do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,26 +2,26 @@ require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
   test "time_based_greeting returns good morning for morning hours" do
-    Time.stub :current, Time.new(2024, 1, 1, 8, 0, 0) do
-      assert_equal "Good morning", time_based_greeting
-    end
+    Time.stubs(:current).returns(Time.new(2024, 1, 1, 8, 0, 0))
+
+    assert_equal "Good morning", time_based_greeting
   end
 
   test "time_based_greeting returns good afternoon for afternoon hours" do
-    Time.stub :current, Time.new(2024, 1, 1, 14, 0, 0) do
-      assert_equal "Good afternoon", time_based_greeting
-    end
+    Time.stubs(:current).returns(Time.new(2024, 1, 1, 14, 0, 0))
+
+    assert_equal "Good afternoon", time_based_greeting
   end
 
   test "time_based_greeting returns good evening for evening hours" do
-    Time.stub :current, Time.new(2024, 1, 1, 20, 0, 0) do
-      assert_equal "Good evening", time_based_greeting
-    end
+    Time.stubs(:current).returns(Time.new(2024, 1, 1, 20, 0, 0))
+
+    assert_equal "Good evening", time_based_greeting
   end
 
   test "time_based_greeting returns good evening for late night hours" do
-    Time.stub :current, Time.new(2024, 1, 1, 2, 0, 0) do
-      assert_equal "Good evening", time_based_greeting
-    end
+    Time.stubs(:current).returns(Time.new(2024, 1, 1, 2, 0, 0))
+
+    assert_equal "Good evening", time_based_greeting
   end
 end

--- a/test/helpers/loan_helper_test.rb
+++ b/test/helpers/loan_helper_test.rb
@@ -24,11 +24,9 @@ class LoanHelperTest < ActionView::TestCase
   end
 
   test "smart_interest_rate_default returns appropriate rate for institutional loans" do
-    # Mock Current.family.currency
-    Current.stub :family, OpenStruct.new(currency: "IDR") do
-      rate = smart_interest_rate_default(false, false)
-      assert_equal 12.0, rate
-    end
+    Current.stubs(:family).returns(OpenStruct.new(currency: "IDR"))
+
+    assert_equal 12.0, smart_interest_rate_default(false, false)
   end
 
   test "smart_term_months_default returns shorter term for personal loans" do

--- a/test/models/assistant_message_test.rb
+++ b/test/models/assistant_message_test.rb
@@ -57,12 +57,10 @@ class AssistantMessageTest < ActiveSupport::TestCase
       ai_model: "gpt-4.1"
     )
 
-    # Stub chat to return nil
-    message.stub :chat, nil do
-      # Should not raise error and should not enqueue job
-      assert_no_enqueued_jobs only: Turbo::Streams::BroadcastJob do
-        message.send(:broadcast_replace_to_with_morph)
-      end
+    message.stubs(:chat).returns(nil)
+
+    assert_no_enqueued_jobs only: Turbo::Streams::BroadcastJob do
+      message.send(:broadcast_replace_to_with_morph)
     end
   end
 end

--- a/test/models/provider/yahoo_finance_test.rb
+++ b/test/models/provider/yahoo_finance_test.rb
@@ -145,23 +145,21 @@ class Provider::YahooFinanceTest < ActiveSupport::TestCase
     # Mock a Faraday error
     faraday_error = Faraday::ConnectionFailed.new("Connection failed")
 
-    @provider.stub :client, ->(*) { raise faraday_error } do
-      result = @provider.send(:with_provider_response) { raise faraday_error }
+    @provider.stubs(:client).raises(faraday_error)
+    result = @provider.send(:with_provider_response) { raise faraday_error }
 
-      assert_not result.success?
-      assert_instance_of Provider::YahooFinance::Error, result.error
-    end
+    assert_not result.success?
+    assert_instance_of Provider::YahooFinance::Error, result.error
   end
 
   test "handles rate limit errors" do
     rate_limit_error = Faraday::TooManyRequestsError.new("Rate limit exceeded", { body: "Too many requests" })
 
-    @provider.stub :client, ->(*) { raise rate_limit_error } do
-      result = @provider.send(:with_provider_response) { raise rate_limit_error }
+    @provider.stubs(:client).raises(rate_limit_error)
+    result = @provider.send(:with_provider_response) { raise rate_limit_error }
 
-      assert_not result.success?
-      assert_instance_of Provider::YahooFinance::RateLimitError, result.error
-    end
+    assert_not result.success?
+    assert_instance_of Provider::YahooFinance::RateLimitError, result.error
   end
 
   # ================================

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,6 @@ ENV["API_RATE_LIMITING_ENABLED"] ||= "true"
 ENV["PGGSSENCMODE"] = "disable"
 
 require "rails/test_help"
-# require "minitest/mock"
 require "minitest/autorun"
 require "mocha/minitest"
 require "aasm/minitest"

--- a/test/views/entries/split_group_test.rb
+++ b/test/views/entries/split_group_test.rb
@@ -7,7 +7,7 @@ class EntriesSplitGroupTest < ActionView::TestCase
   end
 
   test "renders account transaction link with legacy tab parameter and stop propagation actions" do
-    split_group = SplitGroup.new(parent: @parent_entry, children: [])
+    split_group = EntriesHelper::SplitGroup.new(parent: @parent_entry, children: [])
 
     render partial: "entries/split_group", locals: { split_group: split_group, view_ctx: "global" }
 
@@ -20,7 +20,7 @@ class EntriesSplitGroupTest < ActionView::TestCase
       assert_match(/click->split-group#stop/, desktop_link["data-action"])
       assert_match(/keydown\.enter->split-group#stop/, desktop_link["data-action"])
       assert_match(/keydown\.space->split-group#stop/, desktop_link["data-action"])
-      assert_match(/turbo_frame=_top/, desktop_link.to_s)
+      assert_equal "_top", desktop_link["data-turbo-frame"]
 
       # Check mobile link has same attributes
       mobile_link = elements.last
@@ -30,7 +30,7 @@ class EntriesSplitGroupTest < ActionView::TestCase
   end
 
   test "renders account name in link text" do
-    split_group = SplitGroup.new(parent: @parent_entry, children: [])
+    split_group = EntriesHelper::SplitGroup.new(parent: @parent_entry, children: [])
 
     render partial: "entries/split_group", locals: { split_group: split_group, view_ctx: "global" }
 
@@ -38,7 +38,7 @@ class EntriesSplitGroupTest < ActionView::TestCase
   end
 
   test "renders split badge with count" do
-    split_group = SplitGroup.new(parent: @parent_entry, children: [])
+    split_group = EntriesHelper::SplitGroup.new(parent: @parent_entry, children: [])
 
     render partial: "entries/split_group", locals: { split_group: split_group, view_ctx: "global" }
 


### PR DESCRIPTION
## Summary
- replace removed Minitest `stub` calls with the repository standard Mocha stubbing API
- reference the split-group value object through its helper namespace and assert the actual Turbo frame attribute
- enable the Plaid feature flag in controller tests that exercise Plaid-enabled behavior
- remove the stale `minitest/mock` comment because Minitest 6 no longer ships that file

## Validation
- focused regression suite: 47 tests, 152 assertions, 0 failures, 0 errors
- full suite: 1,745 tests, 8,576 assertions, 0 failures, 0 errors, 19 skips
- RuboCop passed
- Biome passed
- Brakeman passed with 0 warnings