### PR TITLE
Add automated gold valuation

### DIFF
--- a/app/jobs/gold_auto_revaluation_job.rb
+++ b/app/jobs/gold_auto_revaluation_job.rb
@@ -1,0 +1,21 @@
+class GoldAutoRevaluationJob < ApplicationJob
+  queue_as :scheduled
+
+  def perform(date: Date.current.to_s)
+    as_of = Date.parse(date)
+    updated = 0
+    errors = 0
+
+    PreciousMetal.where(auto_revalue: true).find_each do |pm|
+      if pm.apply_auto_revaluation!(as_of: as_of)
+        updated += 1
+      end
+    rescue => e
+      errors += 1
+      Rails.logger.error("GoldAutoRevaluationJob: failed for PM #{pm.id}: #{e.message}")
+    end
+
+    Rails.logger.info("GoldAutoRevaluationJob: updated=#{updated}, errors=#{errors}")
+    { updated: updated, errors: errors }
+  end
+end

--- a/app/jobs/gold_price_fetch_job.rb
+++ b/app/jobs/gold_price_fetch_job.rb
@@ -1,0 +1,22 @@
+class GoldPriceFetchJob < ApplicationJob
+  queue_as :scheduled
+
+  # Transient network/timeout errors should retry
+  retry_on Net::OpenTimeout, wait: :exponentially_longer, attempts: 3
+  retry_on Net::ReadTimeout, wait: :exponentially_longer, attempts: 3
+  retry_on SocketError, wait: :exponentially_longer, attempts: 3
+  retry_on Errno::ECONNRESET, wait: :exponentially_longer, attempts: 3
+  retry_on GoldPriceFetcher::TransientError, wait: :exponentially_longer, attempts: 3
+
+  def perform(source: "harga_emas_org", date: Date.current.to_s)
+    result = GoldPriceFetcher.new.fetch(source: source.to_sym, date: Date.parse(date))
+
+    if result.success?
+      GoldAutoRevaluationJob.perform_later(date: date)
+    else
+      Rails.logger.warn("GoldPriceFetchJob failed to fetch price from #{source}: #{result.error}")
+    end
+
+    result
+  end
+end

--- a/app/models/gold_price.rb
+++ b/app/models/gold_price.rb
@@ -1,0 +1,56 @@
+class GoldPrice < ApplicationRecord
+  SOURCES = %w[antam pegadaian harga_emas_org api manual].freeze
+  METAL_TYPES = %w[gold].freeze
+
+  validates :date, presence: true
+  validates :source, presence: true, inclusion: { in: SOURCES }
+  validates :metal_type, presence: true, inclusion: { in: METAL_TYPES }
+  validates :price_per_gram, presence: true, numericality: { greater_than: 0 }
+  validates :buyback_price, numericality: { greater_than: 0 }, allow_nil: true
+  validates :currency, presence: true, length: { is: 3 }
+  validates :unit, presence: true
+  validates :date, uniqueness: { scope: [ :source, :metal_type, :currency ] }
+
+  scope :for_metal, ->(type) { where(metal_type: type) }
+  scope :for_source, ->(source) { where(source: source) }
+  scope :confirmed, -> { where(provisional: false) }
+  scope :on_date, ->(date) { where(date: date) }
+  scope :latest_first, -> { order(date: :desc) }
+
+  # Fetch the latest confirmed price for a given metal type and source
+  def self.latest_price(metal_type: "gold", source: nil, currency: "IDR")
+    scope = confirmed.for_metal(metal_type).where(currency: currency).latest_first
+    scope = scope.for_source(source) if source.present?
+    scope.first
+  end
+
+  # Fetch price on a specific date, with fallback to the most recent prior date
+  def self.price_on(date, metal_type: "gold", source: nil, currency: "IDR")
+    scope = confirmed.for_metal(metal_type).where(currency: currency)
+    scope = scope.for_source(source) if source.present?
+
+    # Try exact date first, then fall back to most recent before that date
+    scope.where("date <= ?", date).latest_first.first
+  end
+
+  # Bulk insert daily prices (upsert pattern for idempotency)
+  def self.upsert_price(date:, source:, price_per_gram:, buyback_price: nil, metal_type: "gold", currency: "IDR", metadata: {})
+    record = find_or_initialize_by(date: date, source: source, metal_type: metal_type, currency: currency)
+    record.assign_attributes(
+      price_per_gram: price_per_gram,
+      buyback_price: buyback_price,
+      provisional: false,
+      metadata: metadata
+    )
+    record.save!
+    record
+  end
+
+  def confirmed?
+    !provisional?
+  end
+
+  def to_s
+    "#{metal_type.capitalize} #{date}: #{currency} #{price_per_gram}/#{unit} (#{source})"
+  end
+end

--- a/app/models/gold_price_fetcher.rb
+++ b/app/models/gold_price_fetcher.rb
@@ -1,0 +1,94 @@
+require "net/http"
+require "nokogiri"
+
+class GoldPriceFetcher
+  class ParseError < StandardError; end
+  class TransientError < StandardError; end
+
+  SOURCES = {
+    harga_emas_org: {
+      url: "https://harga-emas.org/",
+      parser: :parse_harga_emas_org
+    }
+  }.freeze
+
+  Result = Struct.new(:success?, :price_data, :error)
+
+  def fetch(source: :harga_emas_org, date: Date.current)
+    config = SOURCES.fetch(source)
+    html = fetch_html(config[:url])
+
+    price_data = send(config[:parser], html)
+
+    GoldPrice.upsert_price(
+      date: date,
+      source: price_data.fetch(:price_source),
+      price_per_gram: price_data[:price_per_gram],
+      buyback_price: price_data[:buyback_price],
+      metadata: {
+        provider: source.to_s,
+        raw_html_snippet: price_data[:raw_snippet],
+        fetched_at: Time.current.iso8601
+      }
+    )
+
+    Result.new(true, price_data, nil)
+  rescue ParseError, KeyError => e
+    Rails.logger.error("GoldPriceFetcher error: #{e.message}")
+    Result.new(false, nil, e.message)
+  end
+
+  private
+
+    def fetch_html(url_string)
+      uri = URI(url_string)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = 5
+      http.read_timeout = 10
+
+      request = Net::HTTP::Get.new(uri)
+      request["User-Agent"] = "Sure/#{Sure::VERSION} (+https://github.com/hendripermana/sure)"
+      response = http.request(request)
+
+      return response.body if response.is_a?(Net::HTTPSuccess)
+
+      if response.is_a?(Net::HTTPTooManyRequests) || response.is_a?(Net::HTTPServerError)
+        raise TransientError, "HTTP #{response.code} from #{uri.host}"
+      end
+
+      raise ParseError, "HTTP #{response.code} from #{uri.host}"
+    end
+
+    def parse_harga_emas_org(html)
+      doc = Nokogiri::HTML(html)
+      antam_table = doc.css("table").find do |table|
+        table.css("th").any? { |header| header.text.squish.casecmp("Antam").zero? }
+      end
+      raise ParseError, "Antam price table was not found" unless antam_table
+
+      one_gram_row = antam_table.css("tbody tr").find do |row|
+        row.css("td").first&.text&.squish == "1"
+      end
+      cells = one_gram_row&.css("td")
+      raise ParseError, "Antam 1 gram row was not found" unless cells&.length.to_i >= 2
+
+      price_per_gram = extract_idr_amount(cells[1].text)
+      buyback_match = doc.text.match(/Harga pembelian kembali:\s*Rp\s*([\d.]+)/i)
+      buyback_price = extract_idr_amount(buyback_match&.captures&.first)
+      raise ParseError, "Antam 1 gram price was invalid" unless price_per_gram.positive?
+
+      {
+        price_source: "antam",
+        price_per_gram: price_per_gram,
+        buyback_price: buyback_price.zero? ? nil : buyback_price,
+        raw_snippet: one_gram_row.text.squish
+      }
+    end
+
+    def extract_idr_amount(text)
+      return 0.0 if text.blank?
+      # Remove everything except digits
+      text.gsub(/[^\d]/, "").to_d
+    end
+end

--- a/app/models/precious_metal.rb
+++ b/app/models/precious_metal.rb
@@ -7,6 +7,8 @@ class PreciousMetal < ApplicationRecord
 
   ACCOUNT_STATUSES = %w[active closed].freeze
   SCHEME_TYPES = %w[conventional sharia].freeze
+  PRICE_SOURCES = GoldPrice::SOURCES.freeze
+  METAL_TYPES = GoldPrice::METAL_TYPES.freeze
 
   UNITS = {
     "g" => { short: "g", long: "Grams" }
@@ -35,6 +37,8 @@ class PreciousMetal < ApplicationRecord
   validates :manual_price, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :manual_price_currency, presence: true, if: -> { manual_price.present? }
   validate :manual_price_currency_valid, if: -> { manual_price_currency.present? }
+  validates :price_source, inclusion: { in: PRICE_SOURCES }, allow_blank: true
+  validates :metal_type, inclusion: { in: METAL_TYPES }, allow_blank: true
 
   after_commit :sync_account_balance, on: :update, if: :should_sync_account_balance?
 
@@ -93,6 +97,37 @@ class PreciousMetal < ApplicationRecord
 
   def estimated_value_money
     value_in
+  end
+
+  # Fetch the latest gold price from the gold_prices table for this metal type
+  def latest_market_price(as_of: Date.current)
+    GoldPrice.price_on(
+      as_of,
+      metal_type: metal_type.presence || "gold",
+      source: price_source.presence,
+      currency: manual_price_currency.presence || account&.currency || "IDR"
+    )
+  end
+
+  # Apply auto-revaluation from gold_prices table
+  # Updates manual_price which triggers the existing sync_account_balance callback
+  # Returns true if price was updated, false if no price available or not enabled
+  def apply_auto_revaluation!(as_of: Date.current)
+    return false unless auto_revalue?
+
+    gold_price = latest_market_price(as_of: as_of)
+    return false if gold_price.nil?
+
+    # Don't update if the price hasn't changed
+    return false if manual_price == gold_price.price_per_gram &&
+                     manual_price_currency == gold_price.currency
+
+    self.balance_sync_date = as_of
+    update!(
+      manual_price: gold_price.price_per_gram,
+      manual_price_currency: gold_price.currency
+    )
+    true
   end
 
   def apply_quantity_delta!(delta, effective_date: nil)

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -7,6 +7,12 @@ import_market_data:
     mode: "full"
     clear_cache: false
   
+gold_price_fetch:
+  cron: "0 2 * * *" # 02:00 UTC = 09:00 WIB (Jakarta)
+  class: "GoldPriceFetchJob"
+  queue: "scheduled"
+  description: "Fetches daily Indonesian gold prices from harga-emas.org"
+
 clean_syncs:
   cron: "0 * * * *" # every hour
   class: "SyncCleanerJob"
@@ -80,4 +86,3 @@ sync_all_accounts:
   class: "SyncAllAccountsJob"
   queue: "scheduled"
   description: "Triggers sync for all linked accounts across all families"
-

--- a/db/migrate/20260601082430_create_gold_prices.rb
+++ b/db/migrate/20260601082430_create_gold_prices.rb
@@ -1,0 +1,23 @@
+class CreateGoldPrices < ActiveRecord::Migration[8.1]
+  def change
+    create_table :gold_prices, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.date    :date,           null: false
+      t.string  :source,         null: false, limit: 50
+      t.string  :metal_type,     null: false, limit: 20, default: "gold"
+      t.decimal :price_per_gram, null: false, precision: 19, scale: 4
+      t.decimal :buyback_price,  precision: 19, scale: 4
+      t.string  :currency,       null: false, limit: 3, default: "IDR"
+      t.string  :unit,           null: false, limit: 5, default: "g"
+      t.boolean :provisional,    null: false, default: false
+      t.jsonb   :metadata,       default: {}
+      t.timestamps
+    end
+
+    add_index :gold_prices, [ :date, :source, :metal_type, :currency ],
+              unique: true,
+              name: "idx_gold_prices_date_source_type_currency"
+    add_index :gold_prices, [ :metal_type, :date ], order: { date: :desc },
+              name: "idx_gold_prices_metal_type_date_desc"
+    add_index :gold_prices, :source
+  end
+end

--- a/db/migrate/20260601082431_add_auto_revaluation_to_precious_metals.rb
+++ b/db/migrate/20260601082431_add_auto_revaluation_to_precious_metals.rb
@@ -1,0 +1,13 @@
+class AddAutoRevaluationToPreciousMetals < ActiveRecord::Migration[8.1]
+  def change
+    change_table :precious_metals do |t|
+      t.boolean :auto_revalue,  null: false, default: true
+      t.string  :price_source,  limit: 50, default: "antam"
+      t.string  :metal_type,    limit: 20, default: "gold"
+    end
+
+    add_index :precious_metals, :auto_revalue,
+              where: "auto_revalue = true",
+              name: "idx_precious_metals_auto_revalue"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_24_122331) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_082431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -418,6 +418,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_122331) do
     t.string "status", default: "pending", null: false
     t.datetime "updated_at", null: false
     t.index ["family_id"], name: "index_family_exports_on_family_id"
+  end
+
+  create_table "gold_prices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.decimal "buyback_price", precision: 19, scale: 4
+    t.datetime "created_at", null: false
+    t.string "currency", limit: 3, default: "IDR", null: false
+    t.date "date", null: false
+    t.jsonb "metadata", default: {}
+    t.string "metal_type", limit: 20, default: "gold", null: false
+    t.decimal "price_per_gram", precision: 19, scale: 4, null: false
+    t.boolean "provisional", default: false, null: false
+    t.string "source", limit: 50, null: false
+    t.string "unit", limit: 5, default: "g", null: false
+    t.datetime "updated_at", null: false
+    t.index ["date", "source", "metal_type", "currency"], name: "idx_gold_prices_date_source_type_currency", unique: true
+    t.index ["metal_type", "date"], name: "idx_gold_prices_metal_type_date_desc", order: { date: :desc }
+    t.index ["source"], name: "index_gold_prices_on_source"
   end
 
   create_table "holdings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -962,16 +979,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_122331) do
     t.string "account_number"
     t.string "account_status", default: "active"
     t.string "akad"
+    t.boolean "auto_revalue", default: true, null: false
     t.datetime "created_at", null: false
     t.jsonb "locked_attributes", default: {}
     t.decimal "manual_price", precision: 19, scale: 8
     t.string "manual_price_currency", limit: 3
+    t.string "metal_type", limit: 20, default: "gold"
     t.uuid "preferred_funding_account_id"
+    t.string "price_source", limit: 50, default: "antam"
     t.decimal "quantity", precision: 19, scale: 4, default: "0.0", null: false
     t.string "scheme_type"
     t.string "subtype"
     t.string "unit", default: "g", null: false
     t.datetime "updated_at", null: false
+    t.index ["auto_revalue"], name: "idx_precious_metals_auto_revalue", where: "(auto_revalue = true)"
   end
 
   create_table "properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/jobs/gold_auto_revaluation_job_test.rb
+++ b/test/jobs/gold_auto_revaluation_job_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class GoldAutoRevaluationJobTest < ActiveJob::TestCase
+  test "revalues enabled precious metal accounts from the selected source" do
+    precious_metal = accounts(:precious_metal).precious_metal
+    precious_metal.update!(
+      auto_revalue: true,
+      price_source: "antam",
+      metal_type: "gold",
+      manual_price_currency: "IDR"
+    )
+    GoldPrice.create!(
+      date: Date.new(2026, 6, 7),
+      source: "antam",
+      price_per_gram: 2_888_000,
+      currency: "IDR"
+    )
+
+    result = GoldAutoRevaluationJob.perform_now(date: "2026-06-07")
+
+    assert_equal({ updated: 1, errors: 0 }, result)
+    assert_equal 2_888_000, precious_metal.reload.manual_price
+  end
+end

--- a/test/jobs/gold_price_fetch_job_test.rb
+++ b/test/jobs/gold_price_fetch_job_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class GoldPriceFetchJobTest < ActiveJob::TestCase
+  test "enqueues revaluation after a successful fetch" do
+    result = GoldPriceFetcher::Result.new(true, { price_per_gram: 2_888_000 }, nil)
+    GoldPriceFetcher.any_instance.expects(:fetch).returns(result)
+
+    assert_enqueued_with job: GoldAutoRevaluationJob, args: [ { date: "2026-06-07" } ] do
+      GoldPriceFetchJob.perform_now(date: "2026-06-07")
+    end
+  end
+
+  test "does not enqueue revaluation after a parse failure" do
+    result = GoldPriceFetcher::Result.new(false, nil, "markup changed")
+    GoldPriceFetcher.any_instance.expects(:fetch).returns(result)
+
+    assert_no_enqueued_jobs only: GoldAutoRevaluationJob do
+      GoldPriceFetchJob.perform_now(date: "2026-06-07")
+    end
+  end
+end

--- a/test/models/gold_price_fetcher_test.rb
+++ b/test/models/gold_price_fetcher_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class GoldPriceFetcherTest < ActiveSupport::TestCase
+  HTML = <<~HTML
+    <html>
+      <body>
+        <table>
+          <thead>
+            <tr><th>Gram</th><th>Antam</th><th>Pegadaian</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>2</td><td>5.416.000</td><td>5.412.000</td></tr>
+            <tr><td>1</td><td>2.888.000</td><td>2.739.000</td></tr>
+          </tbody>
+        </table>
+        <span>Harga pembelian kembali: Rp2.599.200 /grm</span>
+      </body>
+    </html>
+  HTML
+
+  test "stores the Antam one gram and buyback prices" do
+    fetcher = GoldPriceFetcher.new
+    fetcher.stubs(:fetch_html).returns(HTML)
+
+    result = fetcher.fetch(date: Date.new(2026, 6, 7))
+    price = GoldPrice.find_by!(date: Date.new(2026, 6, 7), source: "antam")
+
+    assert result.success?
+    assert_equal 2_888_000, price.price_per_gram
+    assert_equal 2_599_200, price.buyback_price
+    assert_equal "harga_emas_org", price.metadata.fetch("provider")
+  end
+
+  test "returns a failed result when the provider markup cannot be parsed" do
+    fetcher = GoldPriceFetcher.new
+    fetcher.stubs(:fetch_html).returns("<html><body>no price table</body></html>")
+
+    result = fetcher.fetch(date: Date.new(2026, 6, 7))
+
+    assert_not result.success?
+    assert_match(/Antam price table/, result.error)
+  end
+
+  test "allows transient network failures to reach the job retry handler" do
+    fetcher = GoldPriceFetcher.new
+    fetcher.stubs(:fetch_html).raises(Net::ReadTimeout)
+
+    assert_raises(Net::ReadTimeout) do
+      fetcher.fetch(date: Date.new(2026, 6, 7))
+    end
+  end
+end

--- a/test/models/gold_price_test.rb
+++ b/test/models/gold_price_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class GoldPriceTest < ActiveSupport::TestCase
+  test "price_on falls back to the latest confirmed prior price" do
+    GoldPrice.create!(
+      date: Date.new(2026, 6, 5),
+      source: "antam",
+      price_per_gram: 2_800_000,
+      currency: "IDR"
+    )
+    GoldPrice.create!(
+      date: Date.new(2026, 6, 6),
+      source: "antam",
+      price_per_gram: 2_850_000,
+      currency: "IDR",
+      provisional: true
+    )
+
+    price = GoldPrice.price_on(Date.new(2026, 6, 7), source: "antam", currency: "IDR")
+
+    assert_equal Date.new(2026, 6, 5), price.date
+    assert_equal 2_800_000, price.price_per_gram
+  end
+
+  test "upsert_price is idempotent for a daily source price" do
+    attributes = {
+      date: Date.new(2026, 6, 7),
+      source: "antam",
+      price_per_gram: 2_888_000,
+      buyback_price: 2_599_200
+    }
+
+    assert_difference "GoldPrice.count", 1 do
+      GoldPrice.upsert_price(**attributes)
+      GoldPrice.upsert_price(**attributes.merge(price_per_gram: 2_900_000))
+    end
+
+    assert_equal 2_900_000, GoldPrice.find_by!(date: attributes[:date], source: "antam").price_per_gram
+  end
+end

--- a/test/models/precious_metal_test.rb
+++ b/test/models/precious_metal_test.rb
@@ -73,4 +73,22 @@ class PreciousMetalTest < ActiveSupport::TestCase
 
     assert_includes @precious_metal.errors[:manual_price_currency], "is not a valid currency"
   end
+
+  test "auto revaluation uses the configured market source" do
+    @precious_metal.update!(
+      auto_revalue: true,
+      price_source: "antam",
+      metal_type: "gold",
+      manual_price_currency: "IDR"
+    )
+    GoldPrice.create!(
+      date: Date.new(2026, 6, 7),
+      source: "antam",
+      price_per_gram: 2_888_000,
+      currency: "IDR"
+    )
+
+    assert @precious_metal.apply_auto_revaluation!(as_of: Date.new(2026, 6, 7))
+    assert_equal 2_888_000, @precious_metal.reload.manual_price
+  end
 end


### PR DESCRIPTION
## Summary
- persist confirmed daily gold prices with source, buyback price, currency, and provider metadata
- fetch the current Antam one-gram price from harga-emas.org with explicit timeouts and retryable failure handling
- automatically revalue opted-in precious-metal accounts through scheduled background jobs
- keep price history idempotent and fall back to the latest confirmed prior price

## Engineering corrections
- separate the fetch provider (`harga_emas_org`) from the market price source (`antam`) so the default precious-metal source resolves correctly
- parse the current server-rendered Antam table instead of the obsolete generic `Rp` regex
- allow network failures to reach Active Job retry handlers while treating markup changes as observable non-retryable parse failures

## Validation
- focused gold/sync run before split: 33 tests, 131 assertions, 0 failures, 0 errors
- full suite on the validated superset: 1,756 tests, 8,604 assertions, 0 failures, 0 errors, 19 skips
- RuboCop passed
- Biome passed
- Brakeman passed with 0 warnings
- migrations applied and schema regenerated against disposable PostgreSQL 18