### PR TITLE
Harden family sync queries

### DIFF
--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -21,23 +21,6 @@ class Sync < ApplicationRecord
   scope :recent, -> { order(created_at: :desc).limit(100) }
   scope :with_status, ->(status) { where(status: status) }
 
-  # Returns syncs belonging to the given family — either directly (Family syncable)
-  # or through accounts and provider items owned by the family.
-  scope :for_family, ->(family) {
-    where(
-      "(syncs.syncable_type = 'Family' AND syncs.syncable_id = :family_id) OR " \
-      "(syncs.syncable_type = 'Account' AND syncs.syncable_id IN (:account_ids)) OR " \
-      "(syncs.syncable_type = 'PlaidItem' AND syncs.syncable_id IN (:plaid_item_ids)) OR " \
-      "(syncs.syncable_type = 'SimpleFinItem' AND syncs.syncable_id IN (:simplefin_item_ids)) OR " \
-      "(syncs.syncable_type = 'LunchflowItem' AND syncs.syncable_id IN (:lunchflow_item_ids))",
-      family_id: family.id,
-      account_ids: family.accounts.select(:id),
-      plaid_item_ids: family.plaid_items.select(:id),
-      simplefin_item_ids: family.simplefin_items.select(:id),
-      lunchflow_item_ids: family.lunchflow_items.select(:id)
-    )
-  }
-
   after_commit :update_family_sync_timestamp
   after_commit :enqueue_sync_job, on: :create
 
@@ -105,6 +88,36 @@ class Sync < ApplicationRecord
         map[sync.syncable_id] = sync.sync_stats || {}
       end
     end
+
+    def for_family(family)
+      query = where(syncable_type: "Family", syncable_id: family.id)
+        .or(where(syncable_type: "Account", syncable_id: family.accounts.select(:id)))
+
+      family_syncable_associations.each do |association|
+        query = query.or(
+          where(
+            syncable_type: association.klass.name,
+            syncable_id: family.public_send(association.name).select(:id)
+          )
+        )
+      end
+
+      query
+    end
+
+    def any_incomplete_for?(family)
+      for_family(family).incomplete.exists?
+    end
+
+    private
+      def family_syncable_associations
+        Family.reflect_on_all_associations(:has_many).select do |association|
+          association.name.to_s.end_with?("_items") &&
+            association.klass.included_modules.include?(Syncable)
+        rescue NameError
+          false
+        end
+      end
   end
 
   def perform

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,6 +1,14 @@
 class Transaction < ApplicationRecord
   include Entryable, Transferable, Ruleable
 
+  TRANSFER_KINDS = %w[
+    funds_movement
+    cc_payment
+    loan_payment
+    personal_lending
+    personal_borrowing
+  ].freeze
+
   belongs_to :category, optional: true
   belongs_to :merchant, optional: true
 
@@ -47,7 +55,7 @@ class Transaction < ApplicationRecord
 
   # Overarching grouping method for all transfer-type transactions
   def transfer?
-    funds_movement? || cc_payment? || loan_payment? || personal_lending? || personal_borrowing?
+    kind.in?(TRANSFER_KINDS)
   end
 
   # Islamic finance transaction grouping

--- a/test/models/account/transaction_test.rb
+++ b/test/models/account/transaction_test.rb
@@ -2,4 +2,12 @@ require "test_helper"
 
 class TransactionTest < ActiveSupport::TestCase
   include EntriesTestHelper
+
+  test "transfer classification covers every transfer kind" do
+    Transaction::TRANSFER_KINDS.each do |kind|
+      assert Transaction.new(kind: kind).transfer?, "Expected #{kind} to be classified as a transfer"
+    end
+
+    assert_not Transaction.new(kind: "standard").transfer?
+  end
 end

--- a/test/models/sync_test.rb
+++ b/test/models/sync_test.rb
@@ -247,6 +247,45 @@ class SyncTest < ActiveSupport::TestCase
     assert_includes syncs, sync_account
   end
 
+  test "for_family includes every syncable provider item association" do
+    family = families(:dylan_family)
+    associations = Family.reflect_on_all_associations(:has_many).select do |association|
+      association.name.to_s.end_with?("_items") &&
+        association.klass.included_modules.include?(Syncable)
+    rescue NameError
+      false
+    end
+
+    syncs = associations.filter_map do |association|
+      syncable = family.public_send(association.name).first
+      Sync.create!(syncable: syncable, status: "completed") if syncable
+    end
+
+    assert syncs.any?
+    assert_equal syncs.map(&:id).sort, Sync.for_family(family).where(id: syncs.map(&:id)).pluck(:id).sort
+  end
+
+  test "any_incomplete_for detects family provider syncs" do
+    family = families(:dylan_family)
+    Sync.for_family(family).incomplete.destroy_all
+    provider_association = Family.reflect_on_all_associations(:has_many).find do |association|
+      association.name.to_s.end_with?("_items") &&
+        association.klass.included_modules.include?(Syncable) &&
+        family.public_send(association.name).exists?
+    rescue NameError
+      false
+    end
+
+    assert_not Sync.any_incomplete_for?(family)
+
+    provider_item = family.public_send(provider_association.name).first
+    sync = Sync.create!(syncable: provider_item, status: "pending")
+    assert Sync.any_incomplete_for?(family)
+
+    sync.update!(status: "completed")
+    assert_not Sync.any_incomplete_for?(family)
+  end
+
   test "retry! resets state and re-enqueues sync job" do
     sync = Sync.create!(syncable: accounts(:depository), status: "failed", error: "Fatal error", failed_at: Time.current)
 


### PR DESCRIPTION
## Summary
- replace the hardcoded provider-item sync query with reflection over every family-owned Syncable `*_items` association
- add `Sync.any_incomplete_for?` as a single domain query for family sync state
- centralize transaction transfer kinds to prevent classification drift across Indonesian and standard transfer flows

## Validation
- focused suite: 17 tests, 96 assertions, 0 failures, 0 errors
- full suite: 1,757 tests, 8,610 assertions, 0 failures, 0 errors, 19 skips
- RuboCop passed
- Brakeman passed with 0 warnings