### PR TITLE
Add subscription billing lifecycle

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -7,16 +7,14 @@ class ServicesController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        # All services sorted alphabetically - no distinction between popular and custom
-        @services = ServiceMerchant.order(:name)
+        @services = ServiceMerchant.available_to(Current.family)
       end
       format.turbo_stream do
         # Combobox search endpoint - return services matching search query with pagination
         per_page = 50
         page = (params[:page] || 1).to_i
 
-        # Sort all services alphabetically - no distinction between popular and custom
-        base_query = ServiceMerchant.search(params[:q]).order(:name)
+        base_query = ServiceMerchant.available_to(Current.family).search(params[:q])
 
         total_count = base_query.count
         @services = base_query.offset((page - 1) * per_page).limit(per_page)
@@ -28,18 +26,27 @@ class ServicesController < ApplicationController
   end
 
   def new
-    @service = ServiceMerchant.new
+    @service = ServiceMerchant.new(family: Current.family)
     @categories = ServiceMerchant::CATEGORIES
   end
 
   def create
-    @service = ServiceMerchant.new(service_params)
+    @service = ServiceMerchant.new(service_params.merge(family: Current.family))
 
     respond_to do |format|
       if @service.save
         flash[:notice] = "Service created successfully!"
-        format.html { redirect_to services_path, notice: "Service created successfully!" }
-        format.turbo_stream { render turbo_stream: turbo_stream.action(:redirect, services_path) }
+        return_to = params[:return_to]
+        format.html { redirect_to return_to || services_path, notice: "Service created successfully!" }
+        format.turbo_stream do
+          if return_to.present?
+            # When inside a modal, turbo frame navigation expects turbo_stream to either redirect or update.
+            # Turbo Stream action redirect handles full frame redirects.
+            render turbo_stream: turbo_stream.action(:redirect, return_to)
+          else
+            render turbo_stream: turbo_stream.action(:redirect, services_path)
+          end
+        end
       else
         @categories = ServiceMerchant::CATEGORIES
         format.html { render :new, status: :unprocessable_entity }
@@ -91,12 +98,13 @@ class ServicesController < ApplicationController
     end
 
     def set_service
-      @service = ServiceMerchant.find(params[:id])
+      @service = ServiceMerchant.owned_by(Current.family).find(params[:id])
     end
 
     def service_params
       params.require(:service_merchant).permit(
         :name, :subscription_category, :billing_frequency,
+        :default_interval_count, :default_interval_unit,
         :avg_monthly_cost, :description, :website_url
       )
     end

--- a/app/controllers/subscription_plans_controller.rb
+++ b/app/controllers/subscription_plans_controller.rb
@@ -1,7 +1,10 @@
 class SubscriptionPlansController < ApplicationController
+  include ActionView::RecordIdentifier
+  include Notifiable
+
   before_action :authenticate_user!
-  before_action :set_subscription_plan, only: %i[show edit update destroy pause resume cancel renew]
-  before_action :authorize_family_access, only: %i[show edit update destroy pause resume cancel renew]
+  before_action :set_subscription_plan, only: %i[show edit update destroy pause resume cancel undo_cancellation]
+  before_action :authorize_family_access, only: %i[show edit update destroy pause resume cancel undo_cancellation]
 
   # GET /subscription_plans
   def index
@@ -12,6 +15,8 @@ class SubscriptionPlansController < ApplicationController
 
     # Dashboard data
     @active_subscriptions = @subscription_plans.active
+    @paused_subscriptions = @subscription_plans.where(status: "paused")
+    @cancelled_subscriptions = @subscription_plans.where(status: "cancelled")
     @upcoming_renewals = @subscription_plans.upcoming_renewals
     @overdue_subscriptions = @subscription_plans.overdue
     @trial_ending = @subscription_plans.trial_ending
@@ -27,6 +32,8 @@ class SubscriptionPlansController < ApplicationController
 
   # GET /subscription_plans/1
   def show
+    @entries = Entry.where(id: @subscription_plan.subscription_renewals.where.not(entry_id: nil).pluck(:entry_id)).reverse_chronological
+    @timeline_events = @subscription_plan.audit_logs.reverse_chronological.limit(30)
     respond_to do |format|
       format.html
       format.json { render json: safe_subscription_json(@subscription_plan) }
@@ -40,8 +47,7 @@ class SubscriptionPlansController < ApplicationController
       started_at: Date.current,
       next_billing_at: 1.month.from_now.to_date
     )
-    @services = load_services
-    @accounts = Current.family.accounts
+    load_form_options
 
     respond_to do |format|
       format.html
@@ -62,8 +68,7 @@ class SubscriptionPlansController < ApplicationController
         }
         format.json { render json: safe_subscription_json(@subscription_plan), status: :created }
       else
-        @services = load_services
-        @accounts = Current.family.accounts
+        load_form_options
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @subscription_plan.errors, status: :unprocessable_entity }
       end
@@ -72,8 +77,7 @@ class SubscriptionPlansController < ApplicationController
 
   # GET /subscription_plans/1/edit
   def edit
-    @services = load_services
-    @accounts = Current.family.accounts
+    load_form_options
 
     respond_to do |format|
       format.html
@@ -91,8 +95,7 @@ class SubscriptionPlansController < ApplicationController
         }
         format.json { render json: safe_subscription_json(@subscription_plan) }
       else
-        @services = load_services
-        @accounts = Current.family.accounts
+        load_form_options
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @subscription_plan.errors, status: :unprocessable_entity }
       end
@@ -114,55 +117,81 @@ class SubscriptionPlansController < ApplicationController
 
   # PATCH /subscription_plans/1/pause
   def pause
-    @subscription_plan.pause!
+    success = @subscription_plan.pause!
 
     respond_to do |format|
       format.html {
         redirect_to subscription_plans_path,
-        notice: "Subscription plan paused!"
+          flash: success ? { notice: "Subscription plan paused!" } : { alert: @subscription_plan.errors.full_messages.to_sentence }
       }
-      format.json { render json: safe_subscription_json(@subscription_plan) }
+      format.json {
+        if success
+          render json: safe_subscription_json(@subscription_plan)
+        else
+          render json: { errors: @subscription_plan.errors.full_messages }, status: :unprocessable_entity
+        end
+      }
     end
   end
 
   # PATCH /subscription_plans/1/resume
   def resume
-    @subscription_plan.resume!
+    success = @subscription_plan.resume!
 
     respond_to do |format|
       format.html {
         redirect_to subscription_plans_path,
-        notice: "Subscription plan resumed!"
+          flash: success ? { notice: "Subscription plan resumed!" } : { alert: @subscription_plan.errors.full_messages.to_sentence }
       }
-      format.json { render json: safe_subscription_json(@subscription_plan) }
+      format.json {
+        if success
+          render json: safe_subscription_json(@subscription_plan)
+        else
+          render json: { errors: @subscription_plan.errors.full_messages }, status: :unprocessable_entity
+        end
+      }
     end
   end
 
   # PATCH /subscription_plans/1/cancel
   def cancel
-    @subscription_plan.cancel!
+    at_next_renewal = params[:timing] == "period_end"
+    success = @subscription_plan.cancel!(at_next_renewal: at_next_renewal)
+    notice = at_next_renewal ? "Subscription will cancel at the next renewal." : "Subscription plan cancelled!"
 
     respond_to do |format|
       format.html {
         redirect_to subscription_plans_path,
-        notice: "Subscription plan cancelled!"
+          flash: success ? { notice: notice } : { alert: @subscription_plan.errors.full_messages.to_sentence }
       }
-      format.json { render json: safe_subscription_json(@subscription_plan) }
+      format.json {
+        if success
+          render json: safe_subscription_json(@subscription_plan)
+        else
+          render json: { errors: @subscription_plan.errors.full_messages }, status: :unprocessable_entity
+        end
+      }
     end
   end
 
-  # PATCH /subscription_plans/1/renew
-  def renew
-    @subscription_plan.mark_as_renewed!
+  def undo_cancellation
+    success = @subscription_plan.undo_cancellation!
 
     respond_to do |format|
       format.html {
         redirect_to subscription_plans_path,
-        notice: "Subscription plan renewed!"
+          flash: success ? { notice: "Scheduled cancellation removed." } : { alert: @subscription_plan.errors.full_messages.to_sentence }
       }
-      format.json { render json: safe_subscription_json(@subscription_plan) }
+      format.json {
+        if success
+          render json: safe_subscription_json(@subscription_plan)
+        else
+          render json: { errors: @subscription_plan.errors.full_messages }, status: :unprocessable_entity
+        end
+      }
     end
   end
+
 
   # GET /subscription_plans/check_duplicate
   # Check if user already has a subscription for the given service
@@ -205,6 +234,7 @@ class SubscriptionPlansController < ApplicationController
       permitted = params.require(:subscription_plan).permit(
         :name, :description,
         :amount, :currency, :billing_cycle, :status,
+        :interval_count, :interval_unit,
         :started_at, :trial_ends_at, :next_billing_at,
         :auto_renew, :payment_method, :shared_within_family,
         :max_usage_allowed, :payment_notes
@@ -220,11 +250,6 @@ class SubscriptionPlansController < ApplicationController
         permitted[:merchant_id] = merchant_id if merchant_id.present?
       end
 
-      if params[:subscription_plan].key?(:service_id)
-        service_id = safe_service_id(params[:subscription_plan][:service_id])
-        permitted[:service_id] = service_id if service_id.present?
-      end
-
       permitted
     end
 
@@ -237,14 +262,7 @@ class SubscriptionPlansController < ApplicationController
     def safe_service_merchant_id(merchant_id)
       return if merchant_id.blank?
 
-      ServiceMerchant.where(id: merchant_id).pick(:id)
-    end
-
-    def safe_service_id(service_id)
-      return if service_id.blank?
-      return unless defined?(Service) && Service.table_exists?
-
-      Service.where(id: service_id).pick(:id)
+      ServiceMerchant.available_to(Current.family).where(id: merchant_id).pick(:id)
     end
 
     # Sanitize subscription data for JSON responses to prevent data exposure
@@ -273,20 +291,14 @@ class SubscriptionPlansController < ApplicationController
       hash
     end
 
-    # Load services from both ServiceMerchant and legacy Service tables
-    # Includes both popular services and user-created custom services
     def load_services
-      # Prefer ServiceMerchant, fallback to Service for backward compatibility
-      # Load ALL services (not just popular) to include user-created custom services
-      service_merchants = ServiceMerchant.order(:name)
+      ServiceMerchant.available_to(Current.family)
+    end
 
-      if service_merchants.any?
-        service_merchants
-      elsif defined?(Service) && Service.table_exists?
-        Service.order(:name)
-      else
-        []
-      end
+    def load_form_options
+      @services = load_services
+      @service_schedule_defaults = @services.to_h { |service| [ service.id, service.billing_schedule.to_h ] }
+      @accounts = Current.family.accounts
     end
 
     def track_subscription_created(subscription_plan)

--- a/app/controllers/subscription_renewals_controller.rb
+++ b/app/controllers/subscription_renewals_controller.rb
@@ -1,0 +1,113 @@
+class SubscriptionRenewalsController < ApplicationController
+  include StreamExtensions
+  include Notifiable
+  include ActionView::RecordIdentifier
+
+  before_action :set_subscription_plan
+  before_action :ensure_payable_subscription, only: %i[new create]
+  before_action :set_renewal, only: [ :show ]
+
+  def index
+    @renewals = @subscription_plan.subscription_renewals.reverse_chronological
+    respond_to do |format|
+      format.html { render plain: "Renewals for #{@subscription_plan.name}" }
+      format.json { render json: @renewals }
+    end
+  end
+
+  def new
+    @renewal_form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: @subscription_plan.account_id,
+      actual_amount: @subscription_plan.amount,
+      admin_fee: @subscription_plan.default_admin_fee || 0,
+      paid_at: Date.current,
+      currency: @subscription_plan.currency
+    )
+    @renewal_form.category_id = @renewal_form.default_category_id
+    @accounts = Current.family.accounts
+    @categories = Current.family.categories.where(classification: "expense").order(:name)
+  end
+
+  def create
+    @renewal_form = SubscriptionPlan::RenewalForm.new(form_params.merge(subscription_plan: @subscription_plan, currency: @subscription_plan.currency))
+    renewal = @renewal_form.create
+
+    if renewal
+      respond_to do |format|
+        format.turbo_stream do
+          flash.now[:notice] = "Payment recorded successfully!"
+          render turbo_stream: [
+            turbo_stream.update("modal", ""),
+            Array(flash_notification_stream_items),
+            turbo_stream.replace(
+              dom_id(@subscription_plan, :row),
+              partial: "subscription_plans/row",
+              locals: { subscription: @subscription_plan }
+            )
+          ].flatten
+        end
+        format.html { redirect_to subscription_plans_path, notice: "Payment recorded successfully!" }
+      end
+    else
+      @accounts = Current.family.accounts
+      @categories = Current.family.categories.where(classification: "expense").order(:name)
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace("modal", template: "subscription_renewals/new", layout: false), status: :unprocessable_entity
+        end
+        format.html { render :new, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def show
+    respond_to do |format|
+      format.html { render plain: "Renewal ##{@renewal.id}" }
+      format.json { render json: @renewal }
+    end
+  end
+
+  private
+
+    def set_subscription_plan
+      @subscription_plan = Current.family.subscription_plans.find(params[:subscription_plan_id])
+    end
+
+    def set_renewal
+      @renewal = @subscription_plan.subscription_renewals.find(params[:id])
+    end
+
+    def ensure_payable_subscription
+      return if @subscription_plan.active_or_trial?
+
+      redirect_to subscription_plan_path(@subscription_plan),
+        alert: "Payments can only be recorded for active or trial subscriptions."
+    end
+
+    def form_params
+      raw_params = params.require(:subscription_plan_renewal_form)
+      permitted = raw_params.permit(
+        :actual_amount,
+        :admin_fee,
+        :paid_at,
+        :payment_method,
+        :notes,
+        :update_default_account
+      )
+
+      if raw_params.key?(:account_id)
+        permitted[:account_id] =
+          @subscription_plan.family.accounts.where(id: raw_params[:account_id]).pick(:id) ||
+          raw_params[:account_id]
+      end
+
+      if raw_params.key?(:category_id)
+        permitted[:category_id] =
+          @subscription_plan.family.categories.where(id: raw_params[:category_id]).pick(:id) ||
+          raw_params[:category_id]
+      end
+
+      permitted
+    end
+end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -474,21 +474,7 @@ class TransactionsController < ApplicationController
       subscription = Current.family.subscription_plans.find_by(id: subscription_plan_id)
       return unless subscription
 
-      # Only treat outflows, matching currency, account, and a similar amount
-      # as valid subscription payments.
-      return unless entry.amount.positive?
-      return unless entry.currency == subscription.currency
-      return unless subscription.account_id == entry.account_id
-
-      # Require the payment amount to be reasonably close to the
-      # subscription amount so that unrelated expenses do not
-      # accidentally advance the billing schedule. We accept payments
-      # within ~10% of the configured subscription amount.
-      amount_tolerance = subscription.amount / 10
-      difference = (entry.amount - subscription.amount).abs
-      return unless difference <= amount_tolerance
-
-      billing_advanced = subscription.record_manual_payment!(paid_at: entry.date)
+      billing_advanced = subscription.record_payment_entry!(entry)
       if billing_advanced
         flash[:notice] = "Transaction created. #{subscription.name} billing advanced to #{subscription.next_billing_at.strftime('%b %d, %Y')}."
       end

--- a/app/helpers/subscription_plans_helper.rb
+++ b/app/helpers/subscription_plans_helper.rb
@@ -1,17 +1,16 @@
 module SubscriptionPlansHelper
   def subscription_row_class(subscription)
-    base = "transition-colors"
+    base = "group cursor-pointer border-l-4 border-transparent transition-colors hover:bg-container-hover"
     return base unless subscription.present?
 
     days_until = subscription.days_until_renewal
 
-    if days_until.present? && days_until <= 3 && subscription.active?
-      # Highlight subscriptions that are due soon while staying theme-aware
-      class_names(base, "bg-orange-50 theme-dark:bg-orange-900/20")
+    if subscription.cancelled? || subscription.expired?
+      class_names(base, "border-l-gray-300 bg-container-inset/60 opacity-75 theme-dark:border-l-gray-700")
     elsif subscription.paused?
-      class_names(base, "bg-yellow-50 theme-dark:bg-yellow-900/20")
-    elsif subscription.cancelled? || subscription.expired?
-      class_names(base, "bg-gray-50 theme-dark:bg-gray-900/40")
+      class_names(base, "border-l-yellow-500 bg-yellow-tint-5 theme-dark:bg-yellow-tint-10")
+    elsif days_until.present? && days_until <= 3 && subscription.active?
+      class_names(base, "border-l-orange-500 bg-orange-tint-5 theme-dark:bg-orange-tint-10")
     else
       base
     end
@@ -52,8 +51,110 @@ module SubscriptionPlansHelper
     end
   end
 
+  def subscription_lifecycle_label(subscription)
+    return "Cancels at renewal" if subscription.pending_cancellation?
+
+    case subscription.status
+    when "payment_failed"
+      "Payment failed"
+    else
+      subscription.status.humanize
+    end
+  end
+
+  def subscription_lifecycle_icon(subscription)
+    return "calendar-x" if subscription.pending_cancellation?
+
+    case subscription.status
+    when "active"
+      "check-circle-2"
+    when "trial"
+      "sparkles"
+    when "paused"
+      "pause-circle"
+    when "cancelled", "expired"
+      "x-circle"
+    when "payment_failed"
+      "alert-triangle"
+    when "pending"
+      "clock"
+    else
+      "circle"
+    end
+  end
+
+  def subscription_lifecycle_badge_class(subscription)
+    if subscription.pending_cancellation?
+      return "border-orange-200 bg-orange-50 text-orange-700 theme-dark:border-orange-900/60 theme-dark:bg-orange-tint-10 theme-dark:text-orange-200"
+    end
+
+    case subscription.status
+    when "active"
+      "border-green-200 bg-green-50 text-green-700 theme-dark:border-green-900/60 theme-dark:bg-green-tint-10 theme-dark:text-green-200"
+    when "trial"
+      "border-blue-200 bg-blue-50 text-blue-700 theme-dark:border-blue-900/60 theme-dark:bg-blue-tint-10 theme-dark:text-blue-200"
+    when "paused"
+      "border-yellow-200 bg-yellow-50 text-yellow-800 theme-dark:border-yellow-900/60 theme-dark:bg-yellow-tint-10 theme-dark:text-yellow-200"
+    when "cancelled", "expired"
+      "border-gray-200 bg-gray-100 text-gray-700 theme-dark:border-gray-800 theme-dark:bg-gray-900/50 theme-dark:text-gray-300"
+    when "payment_failed"
+      "border-red-200 bg-red-50 text-red-700 theme-dark:border-red-900/60 theme-dark:bg-red-tint-10 theme-dark:text-red-200"
+    else
+      "border-primary bg-surface text-secondary"
+    end
+  end
+
+  def subscription_billing_state_label(subscription)
+    return "Final cycle" if subscription.pending_cancellation?
+    return "Renewal paused" if subscription.paused?
+    return "Ended" if subscription.cancelled?
+    return "Expired" if subscription.expired?
+    return "Payment failed" if subscription.payment_failed?
+
+    subscription.billing_state.to_s.humanize
+  end
+
+  def subscription_billing_state_dot_class(subscription)
+    state = if subscription.paused?
+      :paused
+    elsif subscription.cancelled? || subscription.expired?
+      :ended
+    elsif subscription.payment_failed?
+      :payment_failed
+    else
+      subscription.billing_state
+    end
+
+    case state
+    when :paid
+      "bg-green-500"
+    when :upcoming
+      "bg-blue-500"
+    when :open_for_payment
+      "bg-orange-500"
+    when :overdue, :payment_failed
+      "bg-red-500"
+    when :paused
+      "bg-yellow-500"
+    when :ended
+      "bg-gray-400"
+    else
+      "bg-secondary"
+    end
+  end
+
   def billing_cycle_options
     SubscriptionPlan.billing_cycles.keys.map { |k| [ k.humanize, k ] }
+  end
+
+  def recurring_interval_unit_options
+    [
+      [ "Days", "day" ],
+      [ "Weeks", "week" ],
+      [ "Months", "month" ],
+      [ "Years", "year" ],
+      [ "One-time", "once" ]
+    ]
   end
 
   def status_options

--- a/app/javascript/controllers/current_date_controller.js
+++ b/app/javascript/controllers/current_date_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["input"];
+  static values = { timezone: String };
+
+  connect() {
+    this.refresh();
+  }
+
+  refresh() {
+    const today = this.todayInTimezone();
+    this.inputTargets.forEach((input) => {
+      input.max = today;
+    });
+  }
+
+  todayInTimezone() {
+    const formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: this.timezoneValue || "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    const parts = Object.fromEntries(
+      formatter.formatToParts(new Date()).map(({ type, value }) => [type, value])
+    );
+
+    return `${parts.year}-${parts.month}-${parts.day}`;
+  }
+}

--- a/app/javascript/controllers/subscription_schedule_controller.js
+++ b/app/javascript/controllers/subscription_schedule_controller.js
@@ -1,0 +1,76 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["count", "countContainer", "unit", "start", "next", "status", "trial"];
+  static values = { serviceDefaults: Object };
+
+  connect() {
+    this.onServiceSelection = this.serviceSelected.bind(this);
+    this.element.addEventListener("hw-combobox:selection", this.onServiceSelection);
+    this.syncIntervalControls();
+  }
+
+  disconnect() {
+    this.element.removeEventListener("hw-combobox:selection", this.onServiceSelection);
+  }
+
+  scheduleChanged() {
+    this.syncIntervalControls();
+    this.updateNextBillingDate();
+  }
+
+  serviceSelected(event) {
+    const schedule = this.serviceDefaultsValue[event.detail.value];
+    if (!schedule) return;
+
+    this.countTarget.value = schedule.count;
+    this.unitTarget.value = schedule.unit;
+    this.scheduleChanged();
+  }
+
+  trialChanged() {
+    if (this.trialTarget.value && this.statusTarget.value === "active") {
+      this.statusTarget.value = "trial";
+    }
+  }
+
+  syncIntervalControls() {
+    const oneTime = this.unitTarget.value === "once";
+    this.countContainerTarget.classList.toggle("hidden", oneTime);
+    this.countTarget.disabled = oneTime;
+    this.countTarget.required = !oneTime;
+    if (oneTime) this.countTarget.value = 1;
+  }
+
+  updateNextBillingDate() {
+    if (!this.startTarget.value || !this.unitTarget.value) return;
+
+    const count = Number.parseInt(this.countTarget.value || "1", 10);
+    if (!Number.isFinite(count) || count < 1) return;
+
+    this.nextTarget.value = this.advance(this.startTarget.value, count, this.unitTarget.value);
+  }
+
+  advance(dateString, count, unit) {
+    if (unit === "once") return dateString;
+
+    const [year, month, day] = dateString.split("-").map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+
+    if (unit === "day") date.setUTCDate(date.getUTCDate() + count);
+    if (unit === "week") date.setUTCDate(date.getUTCDate() + count * 7);
+    if (unit === "month") return this.advanceCalendarDate(year, month - 1 + count, day);
+    if (unit === "year") return this.advanceCalendarDate(year + count, month - 1, day);
+
+    return date.toISOString().slice(0, 10);
+  }
+
+  advanceCalendarDate(year, monthIndex, day) {
+    const targetYear = year + Math.floor(monthIndex / 12);
+    const targetMonth = ((monthIndex % 12) + 12) % 12;
+    const lastDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+    const date = new Date(Date.UTC(targetYear, targetMonth, Math.min(day, lastDay)));
+
+    return date.toISOString().slice(0, 10);
+  }
+}

--- a/app/jobs/subscription_renewal_job.rb
+++ b/app/jobs/subscription_renewal_job.rb
@@ -13,19 +13,22 @@ class SubscriptionRenewalJob < ApplicationJob
   def perform(date = Date.current)
     Rails.logger.info("Starting subscription renewals for #{date}")
 
+    reminder_policy = SubscriptionPlan::ReminderPolicy.new(date: date)
+
     # Process renewals for the specified date
     process_renewals_for_date(date)
 
-    # Send renewal reminders
-    send_renewal_reminders(date)
+    # Send renewal and trial reminders through the idempotent audit ledger.
+    reminder_counts = reminder_policy.deliver_upcoming!
 
     # Process trial expirations
-    process_trial_expirations(date)
+    process_trial_expirations(date, reminder_policy: reminder_policy)
 
     # Process subscription expirations
     process_subscription_expirations(date)
 
     Rails.logger.info("Completed subscription renewals for #{date}")
+    { reminders: reminder_counts }
   end
 
   private
@@ -52,9 +55,19 @@ class SubscriptionRenewalJob < ApplicationJob
             # Process Stripe payment
             process_stripe_renewal(subscription)
           else
-            # Manual renewal - just mark as renewed
-            subscription.mark_as_renewed!
-            create_manual_transaction(subscription)
+            # Manual renewal using RenewalForm
+            form = SubscriptionPlan::RenewalForm.new(
+              subscription_plan: subscription,
+              account_id: subscription.account_id,
+              actual_amount: subscription.amount,
+              admin_fee: subscription.default_admin_fee || 0,
+              paid_at: date,
+              payment_method: subscription.payment_method,
+              currency: subscription.currency
+            )
+            unless form.create
+              raise "Failed to create manual renewal: #{form.errors.full_messages.join(', ')}"
+            end
           end
         else
           # Auto-renew disabled - mark as expired if past due
@@ -82,11 +95,20 @@ class SubscriptionRenewalJob < ApplicationJob
         stripe_subscription = Stripe::Subscription.retrieve(subscription.stripe_subscription_id)
 
         if stripe_subscription.status == "active"
-          # Subscription is still active, just update next billing date
-          subscription.mark_as_renewed!
+          billing_period_start = subscription.next_billing_at || Date.current
+          billing_period_end = subscription.calculate_next_billing_date || billing_period_start
 
-          # Create transaction for accounting
-          create_stripe_transaction(subscription, stripe_subscription)
+          ActiveRecord::Base.transaction do
+            create_stripe_transaction(
+              subscription,
+              stripe_subscription,
+              billing_period_start: billing_period_start,
+              billing_period_end: billing_period_end
+            )
+
+            # Advance only after the accounting entry and renewal record are durable.
+            subscription.mark_as_renewed!
+          end
 
           # Send confirmation email
           SubscriptionMailer.renewal_confirmation(subscription).deliver_later
@@ -119,41 +141,50 @@ class SubscriptionRenewalJob < ApplicationJob
       end
     end
 
-    def create_stripe_transaction(subscription, stripe_subscription)
-      # Create transaction record for the renewal
-      transaction = subscription.account.transactions.create!(
-        amount: -subscription.amount, # Negative for expense
-        currency: subscription.currency,
+    def create_stripe_transaction(subscription, stripe_subscription, billing_period_start: subscription.next_billing_at || Date.current, billing_period_end: subscription.calculate_next_billing_date || Date.current)
+      invoice_id = stripe_invoice_id(stripe_subscription)
+
+      entry = subscription.account.entries.create!(
+        name: "Subscription: #{subscription.name}",
         date: Date.current,
-        description: "Subscription renewal: #{subscription.name}",
-        category: find_subscription_category(subscription.family),
-        metadata: {
-          subscription_id: subscription.id,
-          stripe_subscription_id: subscription.stripe_subscription_id,
-          stripe_invoice_id: stripe_subscription.latest_invoice&.id
-        }
+        amount: subscription.amount,
+        currency: subscription.currency,
+        notes: "Stripe subscription renewal",
+        entryable: Transaction.new(
+          kind: "standard",
+          category: find_subscription_category(subscription.family),
+          merchant: subscription.merchant,
+          extra: {
+            subscription_plan_id: subscription.id,
+            stripe_subscription_id: subscription.stripe_subscription_id,
+            stripe_invoice_id: invoice_id
+          }.compact
+        )
       )
 
-      # Update subscription with transaction reference
-      subscription.update!(last_transaction_id: transaction.id)
+      subscription.subscription_renewals.create!(
+        cycle_number: subscription.next_cycle_number,
+        account: subscription.account,
+        entry: entry,
+        billing_period_start: billing_period_start,
+        billing_period_end: billing_period_end,
+        paid_at: Date.current,
+        template_amount: subscription.amount,
+        actual_amount: subscription.amount,
+        admin_fee: subscription.default_admin_fee || 0,
+        currency: subscription.currency,
+        status: "paid",
+        payment_method: subscription.payment_method,
+        metadata: {
+          stripe_subscription_id: subscription.stripe_subscription_id,
+          stripe_invoice_id: invoice_id
+        }.compact
+      )
     end
 
-    def create_manual_transaction(subscription)
-      # Create manual transaction for non-Stripe payments
-      transaction = subscription.account.transactions.create!(
-        amount: -subscription.amount, # Negative for expense
-        currency: subscription.currency,
-        date: Date.current,
-        description: "Manual subscription payment: #{subscription.name}",
-        category: find_subscription_category(subscription.family),
-        metadata: {
-          subscription_id: subscription.id,
-          payment_method: subscription.payment_method
-        }
-      )
-
-      # Update subscription with transaction reference
-      subscription.update!(last_transaction_id: transaction.id)
+    def stripe_invoice_id(stripe_subscription)
+      invoice = stripe_subscription.latest_invoice
+      invoice.respond_to?(:id) ? invoice.id : invoice
     end
 
     # Safely find or create subscription category scoped to family
@@ -204,42 +235,15 @@ class SubscriptionRenewalJob < ApplicationJob
       )
     end
 
-    def send_renewal_reminders(date)
-      Rails.logger.info("Sending renewal reminders for #{date}")
-
-      # Send reminders for upcoming renewals (3 days, 1 day)
-      [ 3, 1 ].each do |days_ahead|
-        reminder_date = date + days_ahead.days
-        subscriptions_reminded = 0
-
-        SubscriptionPlan.active.where(next_billing_at: reminder_date).find_each do |subscription|
-          # Only send reminder if not already sent for this cycle
-          unless subscription.metadata&.dig("reminder_sent_for_cycle", reminder_date.to_s)
-            SubscriptionMailer.renewal_reminder(subscription, days_ahead).deliver_later
-
-            # Track that reminder was sent
-            subscription.update_column(
-              :metadata,
-              (subscription.metadata || {}).deep_merge(
-                "reminder_sent_for_cycle" => { reminder_date.to_s => true }
-              )
-            )
-
-            subscriptions_reminded += 1
-          end
-        end
-
-        Rails.logger.info("Sent #{subscriptions_reminded} renewal reminders for #{days_ahead} days ahead")
-      end
-    end
-
-    def process_trial_expirations(date)
+    def process_trial_expirations(date, reminder_policy: SubscriptionPlan::ReminderPolicy.new(date: date))
       Rails.logger.info("Processing trial expirations for #{date}")
 
       # Find trials ending today
-      trials_ending = SubscriptionPlan.trial.where(trial_ends_at: date)
+      trials_ending = SubscriptionPlan.where(status: %w[trial active], trial_ends_at: date)
 
       trials_ending.find_each do |subscription|
+        reminder_policy.deliver_trial_expired!(subscription)
+
         if subscription.auto_renewal_enabled?
           # Convert trial to active subscription
           subscription.resume!

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -16,6 +16,7 @@ class Account < ApplicationRecord
   has_many :balances, dependent: :destroy
   has_many :loan_installments, dependent: :destroy
   has_many :subscription_plans, dependent: :destroy
+  has_many :subscription_renewals, dependent: :nullify
 
   monetize :balance, :cash_balance
 

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -1,2 +1,6 @@
 class AuditLog < ApplicationRecord
+  belongs_to :auditable, polymorphic: true
+  belongs_to :user, optional: true
+
+  scope :reverse_chronological, -> { order(created_at: :desc) }
 end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -38,12 +38,24 @@ class Family < ApplicationRecord
   has_many :recurring_transactions, dependent: :destroy
   has_many :subscription_plans, dependent: :destroy
 
+  def primary_user
+    users.where(active: true).order(
+      Arel.sql("CASE role WHEN 'super_admin' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END"),
+      :created_at
+    ).first
+  end
+
   validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }
   validates :date_format, inclusion: { in: DATE_FORMATS.map(&:last) }
 
   def assigned_merchants
     merchant_ids = transactions.where.not(merchant_id: nil).pluck(:merchant_id).uniq
     Merchant.where(id: merchant_ids)
+  end
+
+  def available_transaction_merchants
+    service_ids = subscription_plans.where.not(merchant_id: nil).select(:merchant_id)
+    Merchant.where(id: merchants.select(:id)).or(Merchant.where(id: service_ids)).alphabetically
   end
 
   def auto_categorize_transactions_later(transactions)

--- a/app/models/provider/stripe/event_processor.rb
+++ b/app/models/provider/stripe/event_processor.rb
@@ -13,4 +13,16 @@ class Provider::Stripe::EventProcessor
     def event_data
       event.data.object
     end
+
+    def event_id
+      event.respond_to?(:id) ? event.id : event["id"]
+    end
+
+    def event_type
+      event.respond_to?(:type) ? event.type : event["type"]
+    end
+
+    def event_created_at
+      event.respond_to?(:created) ? event.created : event["created"]
+    end
 end

--- a/app/models/provider/stripe/subscription_event_processor.rb
+++ b/app/models/provider/stripe/subscription_event_processor.rb
@@ -2,6 +2,20 @@ class Provider::Stripe::SubscriptionEventProcessor < Provider::Stripe::EventProc
   Error = Class.new(StandardError)
 
   def process
+    if subscription_plan
+      if event_id.present? && event_created_at.present?
+        subscription_plan.apply_stripe_event!(
+          subscription,
+          event_id: event_id,
+          event_type: event_type,
+          event_created_at: event_created_at
+        )
+      else
+        subscription_plan.sync_from_stripe_subscription!(subscription)
+      end
+      return
+    end
+
     raise Error, "Family not found for Stripe customer ID: #{subscription.customer}" unless family
 
     family.subscription.update(
@@ -17,6 +31,10 @@ class Provider::Stripe::SubscriptionEventProcessor < Provider::Stripe::EventProc
   private
     def family
       Family.find_by(stripe_customer_id: subscription.customer)
+    end
+
+    def subscription_plan
+      @subscription_plan ||= SubscriptionPlan.unscoped.find_by(stripe_subscription_id: subscription.id)
     end
 
     def subscription_details

--- a/app/models/recurring/event_recorder.rb
+++ b/app/models/recurring/event_recorder.rb
@@ -1,0 +1,66 @@
+require "zlib"
+
+module Recurring
+  class EventRecorder
+    def self.record!(record:, event:, key:, title:, detail:, severity: "info", metadata: {})
+      new(
+        record: record,
+        event: event,
+        key: key,
+        title: title,
+        detail: detail,
+        severity: severity,
+        metadata: metadata
+      ).record!
+    end
+
+    def initialize(record:, event:, key:, title:, detail:, severity:, metadata:)
+      @record = record
+      @event = event
+      @key = key
+      @title = title
+      @detail = detail
+      @severity = severity
+      @metadata = metadata
+    end
+
+    def record!
+      AuditLog.transaction do
+        lock_key!
+
+        existing_event || AuditLog.create!(
+          auditable: record,
+          event: event,
+          changeset: {
+            "key" => key,
+            "title" => title,
+            "detail" => detail,
+            "severity" => severity,
+            "metadata" => metadata
+          },
+          user_id: Current.user&.id,
+          ip_address: Current.ip_address
+        )
+      end
+    end
+
+    private
+      attr_reader :record, :event, :key, :title, :detail, :severity, :metadata
+
+      def existing_event
+        AuditLog
+          .where(auditable: record, event: event)
+          .where("changeset ->> 'key' = ?", key)
+          .first
+      end
+
+      def lock_key!
+        lock_id = Zlib.crc32("#{record.class.name}:#{record.id}:#{event}:#{key}")
+        lock_id -= 2**32 if lock_id >= 2**31
+        AuditLog.connection.raw_connection.exec_params(
+          "SELECT pg_advisory_xact_lock($1)",
+          [ lock_id ]
+        )
+      end
+  end
+end

--- a/app/models/recurring/schedule.rb
+++ b/app/models/recurring/schedule.rb
@@ -1,0 +1,129 @@
+module Recurring
+  class Schedule
+    UNITS = %w[day week month year once].freeze
+    LEGACY_CYCLES = {
+      "monthly" => [ 1, "month" ],
+      "quarterly" => [ 3, "month" ],
+      "annual" => [ 1, "year" ],
+      "biennial" => [ 2, "year" ],
+      "one_time" => [ 1, "once" ]
+    }.freeze
+
+    attr_reader :count, :unit
+
+    def self.from_subscription(subscription)
+      metadata = subscription.metadata.to_h.fetch("schedule", {})
+      legacy_count, legacy_unit = LEGACY_CYCLES.fetch(subscription.billing_cycle)
+
+      new(
+        count: metadata.fetch("count", legacy_count),
+        unit: metadata.fetch("unit", legacy_unit)
+      )
+    end
+
+    def self.from_recurring_transaction(recurring_transaction)
+      previous_date = recurring_transaction.last_occurrence_date
+      next_date = recurring_transaction.next_expected_date
+      return new(count: 1, unit: "month") if previous_date.blank? || next_date.blank?
+
+      days = (next_date - previous_date).to_i
+      return new(count: days / 7, unit: "week") if days.positive? && (days % 7).zero? && days < 28
+      return new(count: days, unit: "day") if days.positive? && days < 28
+
+      new(count: 1, unit: "month")
+    end
+
+    def self.from_service_merchant(service_merchant)
+      frequency = service_merchant.billing_frequency.to_s
+      return new(count: 1, unit: "month") if frequency.blank?
+
+      legacy = {
+        "daily" => [ 1, "day" ],
+        "weekly" => [ 1, "week" ],
+        "monthly" => [ 1, "month" ],
+        "quarterly" => [ 3, "month" ],
+        "annual" => [ 1, "year" ],
+        "biennial" => [ 2, "year" ],
+        "one_time" => [ 1, "once" ]
+      }[frequency]
+      count, unit = legacy || frequency.match(/\A(\d+)_(day|week|month|year)\z/)&.captures
+
+      new(count: count || 1, unit: unit || "month")
+    end
+
+    def initialize(count:, unit:)
+      @unit = unit.to_s
+      @count = @unit == "once" ? 1 : Integer(count)
+
+      raise ArgumentError, "Interval count must be greater than zero" unless @count.positive?
+      raise ArgumentError, "Unsupported interval unit: #{@unit}" unless UNITS.include?(@unit)
+    end
+
+    def advance(date)
+      return nil if once?
+
+      date.to_date.advance(unit.pluralize.to_sym => count)
+    end
+
+    def occurrences(first_date, through:)
+      return [] if first_date.blank?
+
+      date = first_date.to_date
+      dates = []
+
+      while date <= through.to_date
+        dates << date
+        date = advance(date)
+        break if date.blank?
+      end
+
+      dates
+    end
+
+    def monthly_multiplier
+      case unit
+      when "day" then 30.to_d / count
+      when "week" then 52.to_d / 12 / count
+      when "month" then 1.to_d / count
+      when "year" then 1.to_d / (12 * count)
+      else 0.to_d
+      end
+    end
+
+    def yearly_multiplier
+      monthly_multiplier * 12
+    end
+
+    def label
+      return "One-time" if once?
+      return unit == "day" ? "Daily" : unit == "week" ? "Weekly" : unit == "month" ? "Monthly" : "Annually" if count == 1
+
+      "Every #{count} #{unit.pluralize(count)}"
+    end
+
+    def legacy_cycle
+      LEGACY_CYCLES.find { |_name, value| value == [ count, unit ] }&.first || "monthly"
+    end
+
+    def once?
+      unit == "once"
+    end
+
+    def to_h
+      { "count" => count, "unit" => unit }
+    end
+
+    def service_frequency
+      return "one_time" if once?
+
+      {
+        [ 1, "day" ] => "daily",
+        [ 1, "week" ] => "weekly",
+        [ 1, "month" ] => "monthly",
+        [ 3, "month" ] => "quarterly",
+        [ 1, "year" ] => "annual",
+        [ 2, "year" ] => "biennial"
+      }.fetch([ count, unit ], "#{count}_#{unit}")
+    end
+  end
+end

--- a/app/models/service_merchant.rb
+++ b/app/models/service_merchant.rb
@@ -1,4 +1,6 @@
 class ServiceMerchant < Merchant
+  belongs_to :family, optional: true
+
   # Service categories for subscription services
   CATEGORIES = %w[
     streaming software utilities subscriptions memberships insurance
@@ -13,14 +15,20 @@ class ServiceMerchant < Merchant
     security parking
   ].freeze
 
-  BILLING_FREQUENCIES = %w[monthly annual quarterly biennial one_time].freeze
+  BILLING_FREQUENCIES = %w[daily weekly monthly quarterly annual biennial one_time].freeze
+
+  attr_writer :default_interval_count, :default_interval_unit
 
   validates :subscription_category, inclusion: { in: CATEGORIES }, allow_nil: true
-  validates :billing_frequency, inclusion: { in: BILLING_FREQUENCIES }, allow_nil: true
-  validates :name, uniqueness: { scope: :type }
+  validate :billing_frequency_is_supported
+  validate :apply_default_schedule
+  validates :name, uniqueness: { scope: :family_id }
   validates :avg_monthly_cost, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   scope :popular, -> { where(popular: true) }
+  scope :catalog, -> { where(family_id: nil, popular: true) }
+  scope :owned_by, ->(family) { where(family_id: family.id) }
+  scope :available_to, ->(family) { catalog.or(owned_by(family)).alphabetically }
   scope :by_category, ->(category) { where(subscription_category: category) }
   scope :search, ->(query) {
     return all if query.blank?
@@ -39,10 +47,32 @@ class ServiceMerchant < Merchant
     )
   end
 
+  def billing_schedule
+    Recurring::Schedule.from_service_merchant(self)
+  end
+
+  def default_interval_count
+    @default_interval_count || (billing_frequency.present? ? billing_schedule.count : 1)
+  end
+
+  def default_interval_unit
+    @default_interval_unit || (billing_frequency.present? ? billing_schedule.unit : nil)
+  end
+
+  def formatted_billing_frequency
+    return "No default" if billing_frequency.blank?
+
+    billing_schedule.label
+  end
+
   # Seed popular subscription services
   def self.seed_popular_services
     popular_services.each do |service_data|
-      service = find_or_initialize_by(name: service_data[:name], type: "ServiceMerchant")
+      service = find_or_initialize_by(
+        name: service_data[:name],
+        type: "ServiceMerchant",
+        family_id: nil
+      )
       service.assign_attributes(service_data.except(:name))
       service.website_url ||= derive_website_url(service_data[:name])
 
@@ -187,6 +217,30 @@ class ServiceMerchant < Merchant
   end
 
   private
+
+    def apply_default_schedule
+      return if @default_interval_count.blank? && @default_interval_unit.blank?
+
+      if @default_interval_unit.blank?
+        self.billing_frequency = nil
+        return
+      end
+
+      self.billing_frequency = Recurring::Schedule.new(
+        count: @default_interval_count.presence || 1,
+        unit: @default_interval_unit
+      ).service_frequency
+    rescue ArgumentError => error
+      errors.add(:billing_frequency, error.message)
+    end
+
+    def billing_frequency_is_supported
+      return if billing_frequency.blank?
+
+      Recurring::Schedule.from_service_merchant(self)
+    rescue ArgumentError
+      errors.add(:billing_frequency, "is not supported")
+    end
 
     def self.popular_services
       [

--- a/app/models/stripe_event_receipt.rb
+++ b/app/models/stripe_event_receipt.rb
@@ -1,0 +1,11 @@
+class StripeEventReceipt < ApplicationRecord
+  belongs_to :subscription_plan, optional: true
+
+  enum :status, {
+    processed: "processed",
+    ignored_stale: "ignored_stale"
+  }
+
+  validates :event_id, :event_type, :event_created_at, presence: true
+  validates :event_id, uniqueness: true
+end

--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -1,14 +1,49 @@
 class SubscriptionPlan < ApplicationRecord
   include Monetizable
+  include AuditableChanges
+
+  track_changes_for :status, :amount, :currency, :next_billing_at, :auto_renew,
+    :cancel_at_period_end, :cancelled_at, :expires_at, :payment_method
 
   belongs_to :family
   belongs_to :service, optional: true  # Deprecated: Use merchant instead
   belongs_to :merchant, optional: true # New: ServiceMerchant reference
   belongs_to :account
 
+  attr_writer :interval_count, :interval_unit
+
+  has_many :subscription_renewals, dependent: :destroy
+  has_many :stripe_event_receipts, dependent: :destroy
+  has_many :audit_logs, as: :auditable, dependent: :delete_all
+
   # Returns the associated service (ServiceMerchant or legacy Service)
   def service_merchant
     merchant || service
+  end
+
+  def schedule
+    Recurring::Schedule.from_subscription(self)
+  end
+
+  def interval_count
+    @interval_count || schedule.count
+  end
+
+  def interval_unit
+    @interval_unit || schedule.unit
+  end
+
+  def apply_schedule_attributes
+    return if @interval_count.blank? && @interval_unit.blank?
+
+    selected_schedule = Recurring::Schedule.new(
+      count: @interval_count.presence || schedule.count,
+      unit: @interval_unit.presence || schedule.unit
+    )
+    self.billing_cycle = selected_schedule.legacy_cycle
+    self.metadata = metadata.to_h.merge("schedule" => selected_schedule.to_h)
+  rescue ArgumentError => error
+    errors.add(:billing_cycle, error.message)
   end
 
   # Include monetize after associations for proper setup
@@ -53,6 +88,15 @@ class SubscriptionPlan < ApplicationRecord
   validates :started_at, presence: true
   validates :next_billing_at, presence: true
 
+  # Billing window validations
+  validates :billing_day_start, numericality: { greater_than: 0, less_than_or_equal_to: 31 }, allow_nil: true
+  validates :billing_day_end, numericality: { greater_than: 0, less_than_or_equal_to: 31 }, allow_nil: true
+  validates :default_admin_fee, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :billing_window_valid
+  validate :apply_schedule_attributes
+  validate :next_billing_not_before_start
+  before_validation :normalize_trial_status, on: :create
+
   # Status-specific validations
   with_options if: -> { active? || trial? } do
     validates :next_billing_at, presence: true
@@ -81,6 +125,13 @@ class SubscriptionPlan < ApplicationRecord
   scope :expired, -> { where(status: "expired") }
   scope :payment_failed, -> { where(status: "payment_failed") }
 
+  # Soft-delete scopes
+  scope :kept, -> { where(discarded_at: nil) }
+  scope :discarded, -> { where.not(discarded_at: nil) }
+
+  # Default scope: exclude soft-deleted records
+  default_scope { kept }
+
   # Business logic methods
   def days_until_renewal
     return 0 if next_billing_at.blank?
@@ -93,7 +144,7 @@ class SubscriptionPlan < ApplicationRecord
   end
 
   def expired?
-    expires_at && expires_at < Date.current
+    status == "expired" || (expires_at.present? && expires_at < Date.current)
   end
 
   def cancelled?
@@ -108,32 +159,107 @@ class SubscriptionPlan < ApplicationRecord
     auto_renew && active_or_trial?
   end
 
-  def monthly_equivalent_amount
-    case billing_cycle
-    when "annual"
-      amount / 12.0
-    when "quarterly"
-      amount / 3.0
-    when "biennial"
-      amount / 24.0
+  def pending_cancellation?
+    cancel_at_period_end? && !cancelled? && !expired?
+  end
+
+  def stripe_managed?
+    payment_method_auto? && stripe_subscription_id.present?
+  end
+
+  def stripe_subscription_item_id
+    metadata.dig("stripe", "subscription_item_id")
+  end
+
+  def stripe_pause_collection_behavior
+    metadata.dig("stripe", "pause_collection", "behavior")
+  end
+
+  # Billing window support — flexible due date ranges
+  def has_billing_window?
+    billing_day_start.present? && billing_day_end.present?
+  end
+
+  # Compute the billing window dates for a given month
+  def billing_window_for(date = Date.current)
+    return nil unless has_billing_window?
+
+    month_start = date.beginning_of_month
+    window_start = safe_date(month_start.year, month_start.month, billing_day_start)
+    window_end = safe_date(month_start.year, month_start.month, billing_day_end)
+
+    window_start..window_end
+  end
+
+  # Subscription state relative to the billing window
+  # Returns :upcoming, :open_for_payment, :overdue, or :paid
+  def billing_state(date = Date.current)
+    # Check if already paid for this cycle
+    current_renewal = current_cycle_renewal
+    return :paid if current_renewal&.paid?
+
+    if has_billing_window?
+      window = billing_window_for(date)
+      return :upcoming if date < window.first
+      return :open_for_payment if window.cover?(date)
+      return :overdue if date > window.last
     else
-      amount
+      return :upcoming if next_billing_at.present? && date < next_billing_at
+      return :overdue if next_billing_at.present? && date > next_billing_at
+      return :open_for_payment
     end
+
+    :upcoming
+  end
+
+  # Get the renewal record for the current billing cycle
+  def current_cycle_renewal
+    subscription_renewals.order(cycle_number: :desc).first
+  end
+
+  # Next cycle number for creating a new renewal
+  def next_cycle_number
+    (subscription_renewals.maximum(:cycle_number) || 0) + 1
+  end
+
+  # Build a pre-filled renewal record for the modal form
+  def build_renewal(overrides = {})
+    cycle = next_cycle_number
+    period_start = next_billing_at || Date.current
+    period_end = calculate_next_billing_date || period_start.next_month
+
+    subscription_renewals.build({
+      cycle_number: cycle,
+      account_id: account_id,
+      billing_period_start: period_start,
+      billing_period_end: period_end,
+      template_amount: amount,
+      actual_amount: amount,
+      admin_fee: default_admin_fee || 0,
+      currency: currency,
+      status: "pending"
+    }.merge(overrides))
+  end
+
+  # Soft-delete
+  def discard!
+    update!(discarded_at: Time.current)
+  end
+
+  def undiscard!
+    update!(discarded_at: nil)
+  end
+
+  def discarded?
+    discarded_at.present?
+  end
+
+  def monthly_equivalent_amount
+    (amount * schedule.monthly_multiplier).round(2)
   end
 
   def yearly_equivalent_amount
-    case billing_cycle
-    when "annual"
-      amount
-    when "quarterly"
-      amount * 4
-    when "monthly"
-      amount * 12
-    when "biennial"
-      amount / 2
-    else
-      amount
-    end
+    (amount * schedule.yearly_multiplier).round(2)
   end
 
   def formatted_amount
@@ -141,25 +267,14 @@ class SubscriptionPlan < ApplicationRecord
   end
 
   def formatted_monthly_amount
+    return "Not recurring" if schedule.once?
+
     monthly_amount = monthly_equivalent_amount
     "#{currency} #{monthly_amount.round(2)}/month"
   end
 
   def formatted_billing_cycle
-    case billing_cycle
-    when "monthly"
-      "Monthly"
-    when "annual"
-      "Annually"
-    when "quarterly"
-      "Quarterly"
-    when "biennial"
-      "Biennially"
-    when "one_time"
-      "One-time"
-    else
-      billing_cycle.humanize
-    end
+    schedule.label
   end
 
   def status_badge_class
@@ -210,54 +325,142 @@ class SubscriptionPlan < ApplicationRecord
     return false unless active_or_trial?
 
     paid_date = paid_at.to_date
+    return false unless payment_date_matches_current_cycle?(paid_date)
 
-    # Accept payments within a window around the billing date:
-    # - 5 days before: to account for weekends/holidays and early charges
-    # - 3 days after: grace period for late payments (bank delays, etc.)
-    window_start = next_billing_at - 5.days
-    window_end = next_billing_at + 3.days
+    mark_as_renewed!(paid_at)
+    true
+  end
 
-    return false if paid_date < window_start
-    return false if paid_date > window_end
+  def record_payment_entry!(entry)
+    return false unless next_billing_at.present?
+    return false unless active_or_trial?
+    return false unless entry.amount.positive?
+    return false unless entry.currency == currency
+    return false unless entry.account_id == account_id
+    return false if subscription_renewals.exists?(entry_id: entry.id)
 
-    mark_as_renewed!
+    amount_tolerance = amount / 10
+    return false unless (entry.amount - amount).abs <= amount_tolerance
+    return false unless payment_date_matches_current_cycle?(entry.date)
+
+    ActiveRecord::Base.transaction do
+      subscription_renewals.create!(
+        cycle_number: next_cycle_number,
+        account: entry.account,
+        entry: entry,
+        billing_period_start: next_billing_at,
+        billing_period_end: calculate_next_billing_date || next_billing_at,
+        paid_at: entry.date,
+        template_amount: amount,
+        actual_amount: entry.amount,
+        admin_fee: 0,
+        currency: currency,
+        status: "paid",
+        payment_method: payment_method,
+        notes: entry.notes
+      )
+
+      mark_as_renewed!(entry.date)
+    end
+
     true
   end
 
   # Lifecycle management
-  def mark_as_renewed!
+  def mark_as_renewed!(paid_at = Date.current)
+    if schedule.once?
+      update!(
+        status: "expired",
+        auto_renew: false,
+        expires_at: paid_at.to_date,
+        last_renewal_at: paid_at,
+        failed_payment_alert_sent: false,
+        usage_count: (usage_count || 0) + 1
+      )
+      return
+    end
+
     new_billing_date = calculate_next_billing_date
     raise ArgumentError, "Cannot renew subscription without a valid billing date" unless new_billing_date.present?
 
     update!(
       next_billing_at: new_billing_date,
-      last_renewal_at: Date.current,
+      last_renewal_at: paid_at,
       failed_payment_alert_sent: false,
       usage_count: (usage_count || 0) + 1
     )
   end
 
   def pause!
-    update!(status: "paused")
+    return update!(status: "paused") unless stripe_managed?
+
+    stripe_subscription = update_stripe_collection(pause_collection: { behavior: "void" })
+    return false unless stripe_subscription
+
+    sync_from_stripe_subscription!(stripe_subscription)
+    true
   end
 
   def resume!
-    update!(status: "active")
+    return update!(status: "active") unless stripe_managed?
+
+    stripe_subscription = update_stripe_collection(pause_collection: "")
+    return false unless stripe_subscription
+
+    sync_from_stripe_subscription!(stripe_subscription)
+    true
   end
 
   def cancel!(at_next_renewal: false)
+    if stripe_managed?
+      stripe_subscription = cancel_stripe_subscription(at_period_end: at_next_renewal)
+      return false unless stripe_subscription
+
+      return true
+    end
+
     if at_next_renewal
       update!(
-        status: "cancelled",
-        auto_renew: false
+        status: active? || trial? ? status : "active",
+        auto_renew: false,
+        cancel_at_period_end: true,
+        expires_at: stripe_current_period_end&.to_date || next_billing_at
       )
     else
       update!(
         status: "cancelled",
         cancelled_at: Date.current,
-        auto_renew: false
+        auto_renew: false,
+        cancel_at_period_end: false,
+        expires_at: Date.current
       )
     end
+
+    true
+  end
+
+  def undo_cancellation!
+    return false unless pending_cancellation?
+
+    if stripe_managed?
+      stripe_subscription = Stripe::Subscription.update(
+        stripe_subscription_id,
+        cancel_at_period_end: false
+      )
+      sync_from_stripe_subscription!(stripe_subscription)
+    else
+      update!(
+        cancel_at_period_end: false,
+        auto_renew: true,
+        expires_at: nil
+      )
+    end
+
+    true
+  rescue Stripe::StripeError => e
+    Rails.logger.error("Failed to undo Stripe cancellation for #{name}: #{e.message}")
+    errors.add(:base, "Stripe cancellation update failed: #{e.message}")
+    false
   end
 
   def expire!
@@ -324,6 +527,7 @@ class SubscriptionPlan < ApplicationRecord
         stripe_customer_id: customer_id
       )
 
+      sync_from_stripe_subscription!(stripe_subscription)
       stripe_subscription
     rescue Stripe::StripeError => e
       Rails.logger.error("Failed to create Stripe subscription for #{name}: #{e.message}")
@@ -332,58 +536,248 @@ class SubscriptionPlan < ApplicationRecord
     end
   end
 
-  def update_stripe_subscription(plan_id)
+  def update_stripe_subscription(plan_id, proration_behavior: "create_prorations")
     return unless stripe_subscription_id.present?
 
     begin
-      Stripe::Subscription.update(
+      subscription_item = current_stripe_subscription_item
+      unless subscription_item
+        errors.add(:base, "Stripe subscription has no subscription item to update")
+        return false
+      end
+
+      item_attributes = {
+        id: stripe_value(subscription_item, :id),
+        price: plan_id
+      }
+      quantity = stripe_value(subscription_item, :quantity)
+      item_attributes[:quantity] = quantity if quantity.present?
+
+      stripe_subscription = Stripe::Subscription.update(
         stripe_subscription_id,
-        items: [ {
-          id: stripe_subscription_id,
-          price: plan_id
-        } ]
+        items: [ item_attributes ],
+        proration_behavior: proration_behavior
       )
+
+      sync_from_stripe_subscription!(stripe_subscription)
+      stripe_subscription
     rescue Stripe::StripeError => e
       Rails.logger.error("Failed to update Stripe subscription for #{name}: #{e.message}")
+      errors.add(:base, "Stripe plan update failed: #{e.message}")
       false
     end
   end
 
-  def cancel_stripe_subscription
+  def cancel_stripe_subscription(at_period_end: false)
     return unless stripe_subscription_id.present?
 
     begin
-      Stripe::Subscription.cancel(stripe_subscription_id)
-      update!(stripe_subscription_id: nil, stripe_customer_id: nil)
+      stripe_subscription = if at_period_end
+        Stripe::Subscription.update(stripe_subscription_id, cancel_at_period_end: true)
+      else
+        Stripe::Subscription.cancel(stripe_subscription_id)
+      end
+
+      sync_from_stripe_subscription!(stripe_subscription)
+      stripe_subscription
     rescue Stripe::StripeError => e
       Rails.logger.error("Failed to cancel Stripe subscription for #{name}: #{e.message}")
+      errors.add(:base, "Stripe cancellation failed: #{e.message}")
       false
     end
+  end
+
+  def sync_from_stripe_subscription!(stripe_subscription)
+    stripe_status_value = stripe_value(stripe_subscription, :status)
+    cancel_at_period_end_value = !!stripe_value(stripe_subscription, :cancel_at_period_end)
+    current_period_end_value = stripe_time(stripe_subscription, :current_period_end)
+    cancel_at_value = stripe_time(stripe_subscription, :cancel_at)
+    pause_collection_value = stripe_value(stripe_subscription, :pause_collection)
+    subscription_item = stripe_subscription_item(stripe_subscription)
+
+    attrs = {
+      stripe_status: stripe_status_value,
+      cancel_at_period_end: cancel_at_period_end_value,
+      stripe_current_period_end: current_period_end_value,
+      stripe_cancel_at: cancel_at_value,
+      metadata: metadata_with_stripe_state(
+        subscription_item_id: stripe_value(subscription_item, :id),
+        pause_collection: pause_collection_value
+      )
+    }
+
+    case stripe_status_value
+    when "active"
+      attrs[:status] = pause_collection_value.present? ? "paused" : "active"
+      attrs[:auto_renew] = !cancel_at_period_end_value
+      attrs[:expires_at] = current_period_end_value&.to_date if cancel_at_period_end_value
+    when "trialing"
+      attrs[:status] = "trial"
+      attrs[:auto_renew] = !cancel_at_period_end_value
+      attrs[:trial_ends_at] = current_period_end_value&.to_date if current_period_end_value.present?
+    when "past_due", "unpaid", "incomplete_expired"
+      attrs[:status] = "payment_failed"
+      attrs[:failed_payment_alert_sent] = true
+    when "canceled"
+      attrs[:status] = "cancelled"
+      attrs[:cancelled_at] = cancel_at_value&.to_date || Date.current
+      attrs[:auto_renew] = false
+      attrs[:cancel_at_period_end] = false
+      attrs[:expires_at] = cancel_at_value&.to_date || Date.current
+    end
+
+    update!(attrs)
+  end
+
+  def apply_stripe_event!(stripe_subscription, event_id:, event_type:, event_created_at:)
+    event_time = normalize_stripe_event_time(event_created_at)
+    return false if StripeEventReceipt.exists?(event_id: event_id)
+
+    with_lock do
+      receipt = stripe_event_receipts.create!(
+        event_id: event_id,
+        event_type: event_type,
+        event_created_at: event_time
+      )
+
+      if stripe_last_event_created_at.present? && event_time < stripe_last_event_created_at
+        receipt.update!(status: "ignored_stale")
+        return false
+      end
+
+      sync_from_stripe_subscription!(stripe_subscription)
+      update!(
+        stripe_last_event_id: event_id,
+        stripe_last_event_created_at: event_time
+      )
+    end
+
+    true
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+    raise unless StripeEventReceipt.exists?(event_id: event_id)
+
+    false
+  end
+
+  def calculate_next_billing_date
+    return nil unless next_billing_at.present?
+
+    schedule.advance(next_billing_at)
   end
 
   # Private methods
   private
 
-    def calculate_next_billing_date
-      return nil unless next_billing_at.present?
+    def normalize_trial_status
+      self.status = "trial" if status == "active" && trial_ends_at.present? && trial_ends_at >= Date.current
+    end
 
-      case billing_cycle
-      when "monthly"
-        next_billing_at.next_month
-      when "quarterly"
-        next_billing_at.next_quarter
-      when "annual"
-        next_billing_at.next_year
-      when "biennial"
-        next_billing_at + 2.years
-      else
-        next_billing_at
-      end
+    def next_billing_not_before_start
+      return if started_at.blank? || next_billing_at.blank?
+      return unless next_billing_at < started_at
+
+      errors.add(:next_billing_at, "cannot be before the start date")
     end
 
     def calculate_trial_end_date
       # Default trial period of 7 days
       return nil unless started_at.present?
       started_at + 7.days
+    end
+
+    def billing_window_valid
+      return if billing_day_start.blank? && billing_day_end.blank?
+
+      if billing_day_start.present? ^ billing_day_end.present?
+        errors.add(:base, "Both billing_day_start and billing_day_end must be set together")
+        return
+      end
+
+      if billing_day_end < billing_day_start
+        errors.add(:billing_day_end, "must be on or after billing_day_start")
+      end
+    end
+
+    def safe_date(year, month, day)
+      Date.new(year, month, [ day, Date.new(year, month, -1).day ].min)
+    rescue ArgumentError
+      Date.new(year, month, -1)
+    end
+
+    def stripe_value(object, key)
+      if object.respond_to?(:[])
+        object[key.to_s] || object[key.to_sym]
+      elsif object.respond_to?(key)
+        object.public_send(key)
+      end
+    rescue KeyError, NoMethodError
+      nil
+    end
+
+    def stripe_time(object, key)
+      value = stripe_value(object, key)
+      value ||= stripe_value(stripe_subscription_item(object), key)
+      return value if value.is_a?(Time)
+      return value.to_time if value.respond_to?(:to_time) && !value.is_a?(Integer)
+      return Time.zone.at(value) if value.present?
+
+      nil
+    end
+
+    def stripe_subscription_item(object)
+      items = stripe_value(object, :items)
+      data = stripe_value(items, :data)
+      data&.first
+    end
+
+    def current_stripe_subscription_item
+      stripe_subscription = Stripe::Subscription.retrieve(stripe_subscription_id)
+      stripe_subscription_item(stripe_subscription)
+    end
+
+    def update_stripe_collection(pause_collection:)
+      Stripe::Subscription.update(
+        stripe_subscription_id,
+        pause_collection: pause_collection
+      )
+    rescue Stripe::StripeError => e
+      Rails.logger.error("Failed to update Stripe collection for #{name}: #{e.message}")
+      errors.add(:base, "Stripe pause update failed: #{e.message}")
+      false
+    end
+
+    def metadata_with_stripe_state(subscription_item_id:, pause_collection:)
+      updated_metadata = (metadata || {}).deep_dup
+      stripe_metadata = updated_metadata["stripe"] ||= {}
+
+      stripe_metadata["subscription_item_id"] = subscription_item_id if subscription_item_id.present?
+
+      if pause_collection.present?
+        stripe_metadata["pause_collection"] = {
+          "behavior" => stripe_value(pause_collection, :behavior),
+          "resumes_at" => stripe_value(pause_collection, :resumes_at)
+        }.compact
+      else
+        stripe_metadata.delete("pause_collection")
+      end
+
+      updated_metadata
+    end
+
+    def normalize_stripe_event_time(value)
+      return value if value.is_a?(Time)
+      return value.to_time if value.respond_to?(:to_time) && !value.is_a?(Integer)
+
+      Time.zone.at(value)
+    end
+
+    def payment_date_matches_current_cycle?(paid_date)
+      # Accept payments within a window around the billing date:
+      # - 5 days before: to account for weekends/holidays and early charges
+      # - 3 days after: grace period for late payments and bank delays.
+      window_start = next_billing_at - 5.days
+      window_end = next_billing_at + 3.days
+
+      paid_date >= window_start && paid_date <= window_end
     end
 end

--- a/app/models/subscription_plan/reminder_policy.rb
+++ b/app/models/subscription_plan/reminder_policy.rb
@@ -1,0 +1,101 @@
+class SubscriptionPlan::ReminderPolicy
+  RENEWAL_MILESTONES = [ 3, 1 ].freeze
+  TRIAL_MILESTONES = [ 3, 2, 1 ].freeze
+
+  attr_reader :date
+
+  def initialize(date: Date.current)
+    @date = date.to_date
+  end
+
+  def deliver_upcoming!
+    renewal_count = deliver_renewal_reminders
+    trial_count = deliver_trial_reminders
+
+    { renewal: renewal_count, trial: trial_count }
+  end
+
+  def deliver_trial_expired!(subscription)
+    deliver_once!(
+      subscription,
+      kind: "trial_expired",
+      occurrence_date: subscription.trial_ends_at
+    ) do
+      SubscriptionMailer.trial_expired(subscription).deliver_now
+    end
+  end
+
+  private
+    def deliver_renewal_reminders
+      RENEWAL_MILESTONES.sum do |days_ahead|
+        delivered = 0
+        SubscriptionPlan.active.where(next_billing_at: date + days_ahead.days).find_each do |subscription|
+          delivered += 1 if deliver_once!(
+            subscription,
+            kind: "renewal",
+            occurrence_date: subscription.next_billing_at,
+            days_remaining: days_ahead
+          ) do
+            SubscriptionMailer.renewal_reminder(subscription, days_ahead).deliver_now
+          end
+        end
+        delivered
+      end
+    end
+
+    def deliver_trial_reminders
+      TRIAL_MILESTONES.sum do |days_ahead|
+        delivered = 0
+        SubscriptionPlan.where(status: %w[trial active], trial_ends_at: date + days_ahead.days).find_each do |subscription|
+          delivered += 1 if deliver_once!(
+            subscription,
+            kind: "trial_ending",
+            occurrence_date: subscription.trial_ends_at,
+            days_remaining: days_ahead
+          ) do
+            SubscriptionMailer.trial_ending(subscription, days_ahead).deliver_now
+          end
+        end
+        delivered
+      end
+    end
+
+    def deliver_once!(subscription, kind:, occurrence_date:, days_remaining: nil)
+      key = [ kind, subscription.id, occurrence_date, days_remaining ].compact.join(":")
+      return false if subscription.audit_logs.where(event: "subscription.notification_sent")
+        .where("changeset ->> 'key' = ?", key).exists?
+      return false unless deliverable_recipient?(subscription)
+
+      yield
+      Recurring::EventRecorder.record!(
+        record: subscription,
+        event: "subscription.notification_sent",
+        key: key,
+        title: kind.humanize,
+        detail: notification_detail(kind, days_remaining),
+        metadata: {
+          kind: kind,
+          occurrence_date: occurrence_date,
+          days_remaining: days_remaining
+        }.compact
+      )
+      true
+    end
+
+    def deliverable_recipient?(subscription)
+      email = subscription.family.primary_user&.email.to_s.downcase
+      domain = email.split("@", 2).last
+      deliverable = email.present? && domain.present? &&
+        domain != "example.com" &&
+        !domain.end_with?(".example")
+
+      Rails.logger.warn("Subscription reminder skipped: family #{subscription.family_id} needs a deliverable primary email") unless deliverable
+      deliverable
+    end
+
+    def notification_detail(kind, days_remaining)
+      return "Trial expiration notification sent." if kind == "trial_expired"
+
+      "#{kind.humanize} notification sent #{days_remaining} #{'day'.pluralize(days_remaining)} before occurrence."
+    end
+end

--- a/app/models/subscription_plan/renewal_form.rb
+++ b/app/models/subscription_plan/renewal_form.rb
@@ -1,0 +1,164 @@
+class SubscriptionPlan::RenewalForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :actual_amount, :decimal
+  attribute :admin_fee, :decimal
+  attribute :paid_at, :date
+  attribute :update_default_account, :boolean, default: false
+  attribute :category_id, :string
+
+  attr_accessor :subscription_plan, :account_id, :payment_method, :notes, :cycle_number, :billing_period_start, :billing_period_end, :template_amount, :currency
+
+  validates :subscription_plan, :account_id, :actual_amount, :paid_at, :category_id, presence: true
+  validates :actual_amount, numericality: { greater_than: 0 }
+  validates :admin_fee, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :account_belongs_to_subscription_family
+  validate :category_belongs_to_subscription_family
+
+  def create
+    self.category_id ||= default_category_id
+
+    return nil unless valid?
+
+    renewal = nil
+    entry = nil
+
+    ActiveRecord::Base.transaction do
+      # 1. Update the master default account if requested
+      if update_default_account
+        subscription_plan.update!(account_id: account_id)
+      end
+
+      # 2. Create the Entry -> Transaction (proper pipeline)
+      entry = create_entry!
+
+      # 3. Create the SubscriptionRenewal record
+      renewal = create_renewal!(entry)
+
+      # 4. Advance the subscription's next_billing_at using smart date math
+      subscription_plan.mark_as_renewed!(paid_at)
+    end
+
+    if renewal && entry
+      # OPTIMISTIC UPDATE: Immediate balance update for smooth UI experience
+      account = payment_account
+      entry_amount = entry.amount
+      entry_date = entry.date
+      entry_currency = entry.currency
+
+      if entry_currency == account.currency &&
+         entry_date >= 30.days.ago.to_date &&
+         account.balances.any? &&
+         !account.precious_metal?
+
+        flows_factor = account.asset? ? 1 : -1
+        balance_change = -entry_amount * flows_factor
+        new_balance = account.balance + balance_change
+
+        account.update_columns(
+          balance: new_balance,
+          updated_at: Time.current
+        )
+
+        account.broadcast_replace_to(
+          account.family,
+          target: "account_#{account.id}",
+          partial: "accounts/account",
+          locals: { account: account.reload }
+        )
+      end
+    end
+
+    renewal
+  rescue ActiveRecord::RecordInvalid => e
+    errors.add(:base, e.message)
+    nil
+  end
+
+  def default_category_id
+    return nil unless subscription_plan.present?
+
+    # 1. Last renewal's entry category
+    last_renewal = subscription_plan.subscription_renewals.paid.order(paid_at: :desc).first
+    if last_renewal && last_renewal.entry&.entryable&.respond_to?(:category_id)
+      return last_renewal.entry.entryable.category_id
+    end
+
+    # 2. Existing "Subscription Fees" category
+    category = family.categories.find_by(name: "Subscription Fees", classification: "expense")
+    return category.id if category.present?
+
+    # 3. First expense category
+    family.categories.where(classification: "expense").first&.id
+  end
+
+  private
+
+    def family
+      subscription_plan.family
+    end
+
+    def category
+      @category ||= family.categories.find_by(id: category_id)
+    end
+
+    def payment_account
+      @payment_account ||= family.accounts.find_by(id: account_id)
+    end
+
+    def account_belongs_to_subscription_family
+      return if account_id.blank? || subscription_plan.blank?
+      return if payment_account.present?
+
+      errors.add(:account_id, "is invalid")
+    end
+
+    def category_belongs_to_subscription_family
+      return if category_id.blank? || subscription_plan.blank?
+      return if category.present?
+
+      errors.add(:category_id, "is invalid")
+    end
+
+    def total_deduction
+      (actual_amount || 0) + (admin_fee || 0)
+    end
+
+    def create_entry!
+      account = payment_account
+
+      account.entries.create!(
+        name: "Subscription: #{subscription_plan.name}",
+        date: paid_at,
+        amount: total_deduction, # Positive for expense (decreases asset balance)
+        currency: subscription_plan.currency,
+        notes: notes,
+        entryable: Transaction.new(
+          kind: "standard",
+          category: category,
+          merchant: subscription_plan.merchant
+        )
+      )
+    end
+
+    def create_renewal!(entry)
+      period_start = billing_period_start || subscription_plan.next_billing_at || paid_at
+
+      subscription_plan.subscription_renewals.create!(
+        cycle_number: cycle_number || subscription_plan.next_cycle_number,
+        account_id: account_id,
+        entry_id: entry.id,
+        billing_period_start: period_start,
+        billing_period_end: billing_period_end || subscription_plan.calculate_next_billing_date || period_start,
+        paid_at: paid_at,
+        template_amount: template_amount || subscription_plan.amount,
+        actual_amount: actual_amount,
+        admin_fee: admin_fee || 0,
+        currency: currency || subscription_plan.currency,
+        status: "paid",
+        payment_method: payment_method,
+        notes: notes
+      )
+    end
+end

--- a/app/models/subscription_renewal.rb
+++ b/app/models/subscription_renewal.rb
@@ -1,0 +1,99 @@
+class SubscriptionRenewal < ApplicationRecord
+  include Monetizable
+
+  belongs_to :subscription_plan
+  belongs_to :account
+  belongs_to :entry, optional: true
+
+  monetize :template_amount, :actual_amount, :admin_fee, :total_paid
+
+  STATUSES = %w[pending paid skipped failed refunded].freeze
+
+  validates :cycle_number, presence: true, numericality: { greater_than: 0 }
+  validates :billing_period_start, presence: true
+  validates :billing_period_end, presence: true
+  validates :template_amount, presence: true, numericality: { greater_than: 0 }
+  validates :actual_amount, presence: true, numericality: { greater_than: 0 }
+  validates :admin_fee, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :currency, presence: true, length: { is: 3 }
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :cycle_number, uniqueness: { scope: :subscription_plan_id }
+  validate :billing_period_valid
+  validate :paid_at_required_when_paid
+
+  scope :paid, -> { where(status: "paid") }
+  scope :pending, -> { where(status: "pending") }
+  scope :failed, -> { where(status: "failed") }
+  scope :for_plan, ->(plan) { where(subscription_plan: plan) }
+  scope :chronological, -> { order(billing_period_start: :asc) }
+  scope :reverse_chronological, -> { order(billing_period_start: :desc) }
+
+  # Mark this renewal as paid and link the transaction entry
+  def mark_paid!(paid_at:, actual_amount: nil, admin_fee: nil, account_id: nil, entry_id: nil, notes: nil, payment_method: nil)
+    attrs = {
+      status: "paid",
+      paid_at: paid_at
+    }
+    attrs[:actual_amount] = actual_amount if actual_amount.present?
+    attrs[:admin_fee] = admin_fee if admin_fee.present?
+    attrs[:account_id] = account_id if account_id.present?
+    attrs[:entry_id] = entry_id if entry_id.present?
+    attrs[:notes] = notes if notes.present?
+    attrs[:payment_method] = payment_method if payment_method.present?
+
+    update!(attrs)
+  end
+
+  def mark_failed!(notes: nil)
+    update!(status: "failed", notes: notes)
+  end
+
+  def mark_skipped!(notes: nil)
+    update!(status: "skipped", notes: notes)
+  end
+
+  def paid?
+    status == "paid"
+  end
+
+  def overdue?
+    status == "pending" && billing_period_end < Date.current
+  end
+
+  def within_payment_window?
+    return false unless status == "pending"
+
+    Date.current.between?(billing_period_start, billing_period_end)
+  end
+
+  # Did the user override the default payment account?
+  def account_overridden?
+    account_id != subscription_plan.account_id
+  end
+
+  # Did the actual amount differ from the template?
+  def amount_differs?
+    actual_amount != template_amount
+  end
+
+  private
+
+    def billing_period_valid
+      return if billing_period_start.blank? || billing_period_end.blank?
+
+      if billing_period_end < billing_period_start
+        errors.add(:billing_period_end, "must be on or after billing period start")
+      end
+    end
+
+    def paid_at_required_when_paid
+      return unless status == "paid"
+      return if paid_at.present?
+
+      errors.add(:paid_at, "is required when status is paid")
+    end
+
+    def monetizable_currency
+      currency
+    end
+end

--- a/app/views/services/_form.html.erb
+++ b/app/views/services/_form.html.erb
@@ -1,4 +1,5 @@
 <%= styled_form_with model: @service, url: @service.new_record? ? services_path : service_path(@service), class: "space-y-4" do |f| %>
+  <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
   <% if @service.errors.any? %>
     <%= render "shared/form_errors", model: @service %>
   <% end %>
@@ -11,10 +12,18 @@
         { prompt: "Select a category...", label: "Category" },
         { required: true } %>
 
-    <%= f.select :billing_frequency,
-        ServiceMerchant::BILLING_FREQUENCIES.map { |b| [b.humanize, b] },
-        { label: "Default Billing Frequency" },
-        { required: true } %>
+    <div class="grid grid-cols-[minmax(0,0.7fr)_minmax(0,1fr)] gap-3">
+      <%= f.number_field :default_interval_count,
+          label: "Default repeat",
+          min: 1,
+          max: 365,
+          value: @service.default_interval_count %>
+      <%= f.select :default_interval_unit,
+          recurring_interval_unit_options,
+          { prompt: "No default", label: "Default interval" },
+          {} %>
+    </div>
+    <p class="text-xs text-secondary">Optional preset for new subscriptions, such as 14 days or 2 weeks. Each subscription can override it.</p>
   </section>
 
   <section class="section-card space-y-2">

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -41,7 +41,7 @@
               <table class="w-full">
                 <tbody>
                   <% category_services.each do |service| %>
-                    <tr class="border-b border-subdued last:border-0 hover:bg-surface-hover">
+                    <tr class="border-b border-subdued last:border-0 hover:bg-surface-hover" data-service-id="<%= service.id %>">
                       <td class="py-3 px-4 text-sm">
                         <div class="flex items-center gap-3">
                           <% if service.display_logo_url.present? %>
@@ -51,7 +51,7 @@
                           <% end %>
                           <div>
                             <p class="font-medium text-primary"><%= service.name %></p>
-                            <p class="text-xs text-secondary"><%= service.billing_frequency&.humanize || "Monthly" %></p>
+                            <p class="text-xs text-secondary"><%= service.formatted_billing_frequency %></p>
                           </div>
                         </div>
                       </td>
@@ -69,14 +69,16 @@
                       </td>
                       <td class="py-3 px-4 text-sm text-right">
                         <div class="flex items-center justify-end gap-2">
-                          <%= link_to edit_service_path(service), class: "text-secondary hover:text-primary", data: { turbo_frame: :modal } do %>
-                            <%= icon "pencil", size: "sm" %>
-                          <% end %>
-                          <% if service.subscription_plans.empty? %>
-                            <%= link_to service_path(service),
-                                data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this service?" },
-                                class: "text-secondary hover:text-destructive" do %>
-                              <%= icon "trash-2", size: "sm" %>
+                          <% if service.family_id == Current.family.id %>
+                            <%= link_to edit_service_path(service), class: "text-secondary hover:text-primary", data: { turbo_frame: :modal } do %>
+                              <%= icon "pencil", size: "sm" %>
+                            <% end %>
+                            <% if service.subscription_plans.empty? %>
+                              <%= link_to service_path(service),
+                                  data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this service?" },
+                                  class: "text-secondary hover:text-destructive" do %>
+                                <%= icon "trash-2", size: "sm" %>
+                              <% end %>
                             <% end %>
                           <% end %>
                         </div>

--- a/app/views/subscription_mailer/renewal_reminder.html.erb
+++ b/app/views/subscription_mailer/renewal_reminder.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
       .container { max-width: 600px; margin: 0 auto; padding: 20px; }
@@ -18,22 +18,23 @@
       <div class="header">
         <h1>📅 Subscription Renewal Reminder</h1>
       </div>
-      
+
       <div class="content">
-        <h2>Hello <%= @family&.primary_user&.first_name || 'there' %>!</h2>
-        
+        <h2>Hello <%= @family&.primary_user&.first_name || "there" %>!</h2>
+
         <p>This is a reminder that your subscription will renew soon:</p>
-        
+
         <div class="subscription-details">
-          <h3><%= @subscription.service&.category_icon || '📋' %> <%= @subscription.name %></h3>
-          <p><strong>Service:</strong> <%= @subscription.service&.name || 'Unknown Service' %></p>
+          <% service = @subscription.service_merchant %>
+          <h3><%= service&.category_icon || "📋" %> <%= @subscription.name %></h3>
+          <p><strong>Service:</strong> <%= service&.name || "Unknown Service" %></p>
           <p><strong>Amount:</strong> <%= number_to_currency(@subscription.amount, unit: @subscription.currency + " ") %> / <%= @subscription.billing_cycle %></p>
-          <p><strong>Next Billing Date:</strong> <%= @subscription.next_billing_at&.strftime("%B %d, %Y") || 'Not scheduled' %></p>
+          <p><strong>Next Billing Date:</strong> <%= @subscription.next_billing_at&.strftime("%B %d, %Y") || "Not scheduled" %></p>
           <% if @subscription.auto_renewal_enabled? %>
             <p><strong>Payment Method:</strong> <%= @subscription.payment_method&.humanize %></p>
           <% end %>
         </div>
-        
+
         <% if @days_until_renewal == 0 %>
           <div class="alert">
             <strong>⚡ Action Required Today!</strong><br>
@@ -47,7 +48,7 @@
         <% else %>
           <p><strong>📅 Renewal in <%= @days_until_renewal %> days</strong></p>
         <% end %>
-        
+
         <% if @subscription.auto_renewal_enabled? %>
           <p>Your subscription is set to auto-renew. No action is needed unless you want to:</p>
           <ul>

--- a/app/views/subscription_mailer/trial_ending.html.erb
+++ b/app/views/subscription_mailer/trial_ending.html.erb
@@ -1,0 +1,13 @@
+<h1>Your <%= @subscription.name %> trial ends soon</h1>
+
+<p>
+  The trial ends in <%= pluralize(@days_left, "day") %>
+  on <%= @subscription.trial_ends_at.strftime("%B %d, %Y") %>.
+</p>
+
+<p>
+  Review the subscription before it renews for
+  <strong><%= number_to_currency(@subscription.amount, unit: "#{@subscription.currency} ") %></strong>.
+</p>
+
+<%= link_to "Review subscription", subscription_plan_url(@subscription) %>

--- a/app/views/subscription_mailer/trial_expired.html.erb
+++ b/app/views/subscription_mailer/trial_expired.html.erb
@@ -1,0 +1,8 @@
+<h1>Your <%= @subscription.name %> trial has ended</h1>
+
+<p>
+  The trial ended on <%= @subscription.trial_ends_at.strftime("%B %d, %Y") %>.
+  Its current lifecycle status is available in Subscription Manager.
+</p>
+
+<%= link_to "Review subscription", subscription_plan_url(@subscription) %>

--- a/app/views/subscription_plans/_form.html.erb
+++ b/app/views/subscription_plans/_form.html.erb
@@ -1,14 +1,15 @@
 <%= styled_form_with model: @subscription_plan, class: "space-y-4",
     data: {
-      controller: "subscription-duplicate",
+      controller: "subscription-duplicate subscription-schedule",
       subscription_duplicate_check_url_value: check_duplicate_subscription_plans_path,
-      subscription_duplicate_exclude_id_value: @subscription_plan.persisted? ? @subscription_plan.id : nil
+      subscription_duplicate_exclude_id_value: @subscription_plan.persisted? ? @subscription_plan.id : nil,
+      subscription_schedule_service_defaults_value: @service_schedule_defaults
     } do |f| %>
   <% if @subscription_plan.errors.any? %>
     <%= render "shared/form_errors", model: @subscription_plan %>
   <% end %>
 
-  <section class="section-card space-y-2">
+  <section class="section-card space-y-2 relative z-20">
     <%= f.text_field :name, label: "Subscription Name", placeholder: "e.g., Netflix Premium", required: true %>
 
     <div class="flex items-center gap-2">
@@ -25,7 +26,7 @@
         variant: "ghost",
         size: "sm",
         icon: "plus",
-        href: new_service_path,
+        href: new_service_path(return_to: request.fullpath),
         frame: :modal
       ) %>
     </div>
@@ -43,19 +44,54 @@
   <section class="section-card space-y-2">
     <%= f.money_field :amount, label: "Amount", required: true, default_currency: Current.family.currency %>
 
-    <%= f.select :billing_cycle, billing_cycle_options, { label: "Billing Cycle" }, { required: true } %>
+    <div class="grid grid-cols-[minmax(0,0.7fr)_minmax(0,1fr)] gap-3">
+      <div data-subscription-schedule-target="countContainer">
+        <%= f.number_field :interval_count,
+            label: "Repeat every",
+            min: 1,
+            max: 365,
+            required: true,
+            value: @subscription_plan.interval_count,
+            data: {
+              subscription_schedule_target: "count",
+              action: "input->subscription-schedule#scheduleChanged"
+            } %>
+      </div>
+      <%= f.select :interval_unit,
+          recurring_interval_unit_options,
+          { label: "Interval" },
+          {
+            required: true,
+            data: {
+              subscription_schedule_target: "unit",
+              action: "change->subscription-schedule#scheduleChanged"
+            }
+          } %>
+    </div>
+    <p class="text-xs text-secondary">Examples: 3 days, 2 weeks, 1 month, or 1 year.</p>
 
     <%= f.select :payment_method, payment_method_options, { label: "Payment Method" }, { required: true } %>
 
-    <%= f.select :status, status_options, { label: "Status" }, { required: true } %>
+    <%= f.select :status, status_options, { label: "Status" }, {
+      required: true,
+      data: { subscription_schedule_target: "status" }
+    } %>
   </section>
 
   <section class="section-card space-y-2">
-    <%= f.date_field :started_at, label: "Start Date", required: true %>
+    <%= f.date_field :started_at, label: "Start Date", required: true, data: {
+      subscription_schedule_target: "start",
+      action: "change->subscription-schedule#scheduleChanged"
+    } %>
 
-    <%= f.date_field :next_billing_at, label: "Next Billing Date", required: true %>
+    <%= f.date_field :next_billing_at, label: "Next Billing Date", required: true, data: {
+      subscription_schedule_target: "next"
+    } %>
 
-    <%= f.date_field :trial_ends_at, label: "Trial Ends (optional)" %>
+    <%= f.date_field :trial_ends_at, label: "Trial Ends (optional)", data: {
+      subscription_schedule_target: "trial",
+      action: "change->subscription-schedule#trialChanged"
+    } %>
   </section>
 
   <section class="section-card space-y-2">

--- a/app/views/subscription_plans/_row.html.erb
+++ b/app/views/subscription_plans/_row.html.erb
@@ -1,0 +1,144 @@
+<tr id="<%= dom_id(subscription, :row) %>" class="<%= subscription_row_class(subscription) %>"
+    data-controller="clickable-row"
+    data-clickable-row-url-value="<%= subscription_plan_path(subscription) %>">
+  <% service = subscription.service_merchant %>
+  <%# Service Column - Avatar + Name + Category (Clickable) %>
+  <td class="px-6 py-4" data-clickable-row-target="cell">
+    <div class="flex items-center gap-3">
+      <% if service&.respond_to?(:display_logo_url) && service.display_logo_url.present? %>
+        <%= image_tag service.display_logo_url, class: "h-11 w-11 rounded-2xl object-cover shadow-border-xs", loading: "lazy" %>
+      <% else %>
+        <div class="flex h-11 w-11 items-center justify-center rounded-2xl bg-container-inset text-xl shadow-border-xs">
+          <%= service_icon(service) %>
+        </div>
+      <% end %>
+      <div class="min-w-0">
+        <div class="font-medium text-primary group-hover:text-blue-600 theme-dark:group-hover:text-blue-400 transition-colors"><%= subscription.name %></div>
+        <div class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-secondary">
+          <%= subscription_service_category(subscription)&.humanize || "Subscription" %>
+          <% if subscription.shared_within_family %>
+            <span class="rounded-full bg-blue-tint-10 px-2 py-0.5 text-blue-700 theme-dark:text-blue-200">Shared</span>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </td>
+
+  <%# Amount Column (Clickable) %>
+  <td class="px-6 py-4" data-clickable-row-target="cell">
+    <div class="text-base font-semibold text-primary"><%= number_to_currency(subscription.amount, unit: subscription.currency + " ") %></div>
+    <div class="mt-0.5 text-xs text-secondary"><%= subscription.formatted_billing_cycle %></div>
+  </td>
+
+  <%# Status Column with Dynamic Badge (Clickable) %>
+  <td class="px-6 py-4" data-clickable-row-target="cell">
+    <div class="flex flex-col items-start gap-1.5">
+      <span
+        class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold <%= subscription_lifecycle_badge_class(subscription) %>"
+        data-subscription-status="<%= subscription.status %>">
+        <%= icon subscription_lifecycle_icon(subscription), class: "h-3.5 w-3.5" %>
+        <%= subscription_lifecycle_label(subscription) %>
+      </span>
+      <span class="inline-flex items-center gap-1.5 text-xs text-secondary" data-subscription-billing-state>
+        <span class="h-1.5 w-1.5 rounded-full <%= subscription_billing_state_dot_class(subscription) %>"></span>
+        <%= subscription_billing_state_label(subscription) %>
+      </span>
+    </div>
+    <% if subscription.trial_days_remaining.positive? %>
+      <div class="text-xs text-blue-600 theme-dark:text-blue-400 mt-1"><%= subscription.trial_days_remaining %>d trial</div>
+    <% end %>
+  </td>
+
+  <%# Next Billing Column (Clickable) %>
+  <td class="px-6 py-4" data-clickable-row-target="cell">
+    <% if subscription.next_billing_at %>
+      <% if subscription.cancelled? || subscription.expired? %>
+        <div class="text-sm font-medium text-secondary">No future billing</div>
+        <span class="text-xs text-secondary">Ended subscription</span>
+      <% else %>
+        <div class="text-sm font-medium text-primary"><%= subscription.next_billing_at.strftime("%b %d, %Y") %></div>
+        <% if subscription.days_until_renewal == 0 %>
+          <span class="text-xs font-medium text-orange-600 theme-dark:text-orange-400">Today</span>
+        <% elsif subscription.days_until_renewal <= 3 %>
+          <span class="text-xs font-medium text-red-600 theme-dark:text-red-400"><%= subscription.days_until_renewal %> days</span>
+        <% else %>
+          <span class="text-xs text-secondary"><%= subscription.days_until_renewal %> days</span>
+        <% end %>
+      <% end %>
+    <% else %>
+      <span class="text-sm text-secondary">—</span>
+    <% end %>
+  </td>
+
+  <%# Actions Column - Dropdown Menu + Modal Trigger %>
+  <td class="px-6 py-4 text-right flex items-center justify-end gap-2" data-clickable-row-target="exclude">
+    <% if subscription.active_or_trial? %>
+      <%= link_to new_subscription_plan_subscription_renewal_path(subscription), data: { turbo_frame: "modal" }, class: "flex h-9 w-9 items-center justify-center rounded-full bg-container-inset text-primary shadow-border-xs transition-colors hover:bg-surface-hover", title: "Record Payment" do %>
+        <%= icon "credit-card", class: "h-5 w-5" %>
+      <% end %>
+    <% end %>
+
+    <%= render DS::Menu.new(placement: "bottom-end") do |menu| %>
+      <% menu.with_item(variant: "link", text: "View details", href: subscription_plan_path(subscription), icon: "eye") %>
+      <% menu.with_item(variant: "link", text: "Edit", href: edit_subscription_plan_path(subscription), icon: "pencil") %>
+
+      <% menu.with_item(variant: "divider") %>
+
+      <% if subscription.active? %>
+        <% menu.with_item(variant: "button", text: "Pause", href: pause_subscription_plan_path(subscription), icon: "pause", method: :patch) %>
+      <% elsif subscription.paused? %>
+        <% menu.with_item(variant: "button", text: "Resume", href: resume_subscription_plan_path(subscription), icon: "play", method: :patch) %>
+      <% end %>
+
+      <% menu.with_item(variant: "divider") %>
+
+      <% if subscription.pending_cancellation? %>
+        <% menu.with_item(
+          variant: "button",
+          text: "Keep subscription",
+          href: undo_cancellation_subscription_plan_path(subscription),
+          icon: "rotate-ccw",
+          method: :patch,
+          confirm: "Remove the scheduled cancellation and keep this subscription active?"
+        ) %>
+        <% menu.with_item(
+          variant: "button",
+          text: "Cancel now",
+          href: cancel_subscription_plan_path(subscription, timing: "immediate"),
+          icon: "x-circle",
+          method: :patch,
+          destructive: true,
+          confirm: "Cancel immediately? Access and future billing may stop now."
+        ) %>
+      <% elsif subscription.cancelled? || subscription.expired? %>
+        <% menu.with_item(
+          variant: "button",
+          text: "Delete",
+          href: subscription_plan_path(subscription),
+          icon: "trash-2",
+          method: :delete,
+          destructive: true,
+          confirm: "Are you sure you want to delete this subscription?"
+        ) %>
+      <% else %>
+        <% menu.with_item(
+          variant: "button",
+          text: "Cancel at renewal",
+          href: cancel_subscription_plan_path(subscription, timing: "period_end"),
+          icon: "calendar-x",
+          method: :patch,
+          confirm: "Keep access until the next renewal, then cancel this subscription?"
+        ) %>
+        <% menu.with_item(
+          variant: "button",
+          text: "Cancel now",
+          href: cancel_subscription_plan_path(subscription, timing: "immediate"),
+          icon: "x-circle",
+          method: :patch,
+          destructive: true,
+          confirm: "Cancel immediately? Access and future billing may stop now."
+        ) %>
+      <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/subscription_plans/index.html.erb
+++ b/app/views/subscription_plans/index.html.erb
@@ -1,222 +1,101 @@
-<div class="container mx-auto px-4 py-6">
-  <!-- Page Header -->
-  <div class="mb-8">
-    <div class="flex justify-between items-center">
-      <div>
-        <h1 class="text-3xl font-bold text-primary">Subscription Manager</h1>
-        <p class="text-secondary mt-1">Manage your subscriptions and recurring payments</p>
-      </div>
-      <div>
-        <%= link_to new_subscription_plan_path, class: "inline-flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors" do %>
-          <%= icon "plus", class: "h-5 w-5" %>
-          Add Subscription
-        <% end %>
-      </div>
-    </div>
-  </div>
-
-  <!-- Dashboard Summary Cards - Theme Aware -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
-    <!-- Monthly Recurring Revenue -->
-    <div class="bg-container rounded-xl border border-primary p-5">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <div class="p-2.5 rounded-lg bg-green-100 theme-dark:bg-green-900/30">
-            <%= icon "trending-up", class: "h-5 w-5 text-green-600 theme-dark:text-green-400" %>
-          </div>
-          <div>
-            <p class="text-secondary text-xs font-medium uppercase tracking-wide">Monthly Revenue</p>
-            <p class="text-2xl font-bold text-primary">
-              <%= Money.new(@analytics.mrr, Current.family.currency).format %>
-            </p>
-          </div>
+<div class="mx-auto max-w-[1240px] px-4 py-6 lg:px-8">
+  <section class="mb-8 rounded-[24px] bg-surface p-6 theme-dark:bg-container lg:p-8">
+    <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+      <div class="max-w-3xl">
+        <div class="mb-3 inline-flex items-center gap-2 rounded-full bg-container px-3 py-1 text-xs font-semibold text-secondary shadow-border-xs">
+          <span class="h-2 w-2 rounded-full bg-primary"></span>
+          Recurring money control
         </div>
+        <h1 class="text-4xl font-black leading-none text-primary lg:text-5xl">Subscription Manager</h1>
+        <p class="mt-3 max-w-2xl text-base text-secondary lg:text-lg">Track active, paused, and cancelled commitments without mixing lifecycle status with payment state.</p>
       </div>
-      <p class="text-xs text-secondary mt-3"><%= @active_subscriptions.count %> active subscriptions</p>
+
+      <%= render DS::Link.new(
+        text: "Add Subscription",
+        icon: "plus",
+        variant: :primary,
+        size: :lg,
+        href: new_subscription_plan_path,
+        class: "min-h-12 px-6"
+      ) %>
     </div>
 
-    <!-- Active Subscriptions -->
-    <div class="bg-container rounded-xl border border-primary p-5">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <div class="p-2.5 rounded-lg bg-blue-100 theme-dark:bg-blue-900/30">
-            <%= icon "layers", class: "h-5 w-5 text-blue-600 theme-dark:text-blue-400" %>
-          </div>
-          <div>
-            <p class="text-secondary text-xs font-medium uppercase tracking-wide">Active</p>
-            <p class="text-2xl font-bold text-primary"><%= @active_subscriptions.count %></p>
-          </div>
+    <div class="mt-8 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <div class="rounded-[24px] bg-container p-5 shadow-border-xs">
+        <div class="mb-4 flex items-center justify-between">
+          <span class="rounded-full bg-primary/20 px-3 py-1 text-xs font-semibold text-primary">Monthly</span>
+          <%= icon "wallet-cards", class: "h-5 w-5 text-secondary" %>
         </div>
+        <p class="text-sm font-medium text-secondary">Recurring spend</p>
+        <p class="mt-1 text-3xl font-black text-primary"><%= Money.new(@analytics.mrr, Current.family.currency).format %></p>
+        <p class="mt-3 text-xs text-secondary"><%= @active_subscriptions.count %> active billing streams</p>
       </div>
-      <p class="text-xs text-secondary mt-3">Total subscriptions</p>
-    </div>
 
-    <!-- Upcoming Renewals -->
-    <div class="bg-container rounded-xl border border-primary p-5">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <div class="p-2.5 rounded-lg bg-orange-100 theme-dark:bg-orange-900/30">
-            <%= icon "calendar", class: "h-5 w-5 text-orange-600 theme-dark:text-orange-400" %>
-          </div>
-          <div>
-            <p class="text-secondary text-xs font-medium uppercase tracking-wide">Renewals</p>
-            <p class="text-2xl font-bold text-primary"><%= @upcoming_renewals.count %></p>
-          </div>
+      <div class="rounded-[24px] bg-container p-5 shadow-border-xs">
+        <div class="mb-4 flex items-center justify-between">
+          <span class="rounded-full bg-green-50 px-3 py-1 text-xs font-semibold text-green-700 theme-dark:bg-green-tint-10 theme-dark:text-green-200">Active</span>
+          <%= icon "check-circle-2", class: "h-5 w-5 text-success" %>
         </div>
+        <p class="text-sm font-medium text-secondary">Currently renewing</p>
+        <p class="mt-1 text-3xl font-black text-primary"><%= @active_subscriptions.count %></p>
+        <p class="mt-3 text-xs text-secondary">Included in monthly forecasts</p>
       </div>
-      <p class="text-xs text-secondary mt-3">In next 7 days</p>
-    </div>
 
-    <!-- Overdue Payments -->
-    <div class="bg-container rounded-xl border border-primary p-5">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-3">
-          <div class="p-2.5 rounded-lg bg-red-100 theme-dark:bg-red-900/30">
-            <%= icon "alert-triangle", class: "h-5 w-5 text-red-600 theme-dark:text-red-400" %>
-          </div>
-          <div>
-            <p class="text-secondary text-xs font-medium uppercase tracking-wide">Overdue</p>
-            <p class="text-2xl font-bold text-primary"><%= @overdue_subscriptions.count %></p>
-          </div>
+      <div class="rounded-[24px] bg-container p-5 shadow-border-xs">
+        <div class="mb-4 flex items-center justify-between">
+          <span class="rounded-full bg-yellow-50 px-3 py-1 text-xs font-semibold text-yellow-800 theme-dark:bg-yellow-tint-10 theme-dark:text-yellow-200">Paused</span>
+          <%= icon "pause-circle", class: "h-5 w-5 text-warning" %>
         </div>
+        <p class="text-sm font-medium text-secondary">Temporarily stopped</p>
+        <p class="mt-1 text-3xl font-black text-primary"><%= @paused_subscriptions.count %></p>
+        <p class="mt-3 text-xs text-secondary">Ready to resume later</p>
       </div>
-      <p class="text-xs text-secondary mt-3">Require attention</p>
+
+      <div class="rounded-[24px] bg-container p-5 shadow-border-xs">
+        <div class="mb-4 flex items-center justify-between">
+          <span class="rounded-full bg-red-50 px-3 py-1 text-xs font-semibold text-red-700 theme-dark:bg-red-tint-10 theme-dark:text-red-200">Attention</span>
+          <%= icon "alert-triangle", class: "h-5 w-5 text-destructive" %>
+        </div>
+        <p class="text-sm font-medium text-secondary">Overdue or cancelled</p>
+        <p class="mt-1 text-3xl font-black text-primary"><%= @overdue_subscriptions.count + @cancelled_subscriptions.count %></p>
+        <p class="mt-3 text-xs text-secondary"><%= @overdue_subscriptions.count %> overdue, <%= @cancelled_subscriptions.count %> cancelled</p>
+      </div>
     </div>
-  </div>
+  </section>
 
   <!-- Analytics Charts -->
   <%= render "subscription_plans/analytics_charts" %>
 
   <!-- Subscription List -->
-  <div class="bg-container rounded-xl border border-primary overflow-hidden">
-    <div class="px-6 py-4 border-b border-primary flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-primary">All Subscriptions</h2>
-      <span class="text-sm text-secondary">Showing <%= @subscription_plans.count %> entries</span>
+  <div class="overflow-hidden rounded-[24px] bg-container shadow-border-xs">
+    <div class="flex flex-col gap-4 border-b border-primary px-6 py-5 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <h2 class="text-xl font-semibold text-primary">All Subscriptions</h2>
+        <p class="mt-1 text-sm text-secondary">Lifecycle status and payment state are shown separately.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-2 text-xs font-medium text-secondary">
+        <span class="rounded-full bg-container-inset px-3 py-1 shadow-border-xs">Showing <%= @subscription_plans.count %> entries</span>
+        <span class="rounded-full bg-green-50 px-3 py-1 text-green-700 theme-dark:bg-green-tint-10 theme-dark:text-green-200"><%= @active_subscriptions.count %> active</span>
+        <span class="rounded-full bg-yellow-50 px-3 py-1 text-yellow-800 theme-dark:bg-yellow-tint-10 theme-dark:text-yellow-200"><%= @paused_subscriptions.count %> paused</span>
+        <span class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 theme-dark:bg-gray-800 theme-dark:text-gray-300"><%= @cancelled_subscriptions.count %> cancelled</span>
+      </div>
     </div>
 
     <% if @subscription_plans.any? %>
       <div class="overflow-x-auto">
         <table class="min-w-full">
           <thead>
-            <tr class="border-b border-primary bg-surface">
-              <th class="px-6 py-3 text-left text-xs font-medium text-secondary uppercase tracking-wider">Service</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-secondary uppercase tracking-wider">Amount</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-secondary uppercase tracking-wider">Status</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-secondary uppercase tracking-wider">Next Billing</th>
-              <th class="px-6 py-3 text-right text-xs font-medium text-secondary uppercase tracking-wider">Actions</th>
+            <tr class="border-b border-primary bg-container-inset">
+              <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-secondary">Service</th>
+              <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-secondary">Amount</th>
+              <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-secondary">Lifecycle</th>
+              <th class="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wide text-secondary">Next Billing</th>
+              <th class="px-6 py-4 text-right text-xs font-semibold uppercase tracking-wide text-secondary">Actions</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-primary/10">
+          <tbody class="divide-y divide-tertiary">
             <% @subscription_plans.each do |subscription| %>
-              <% service = subscription.service_merchant %>
-              <tr class="group hover:bg-surface-hover transition-colors cursor-pointer <%= subscription_row_class(subscription) %>"
-                  data-controller="clickable-row"
-                  data-clickable-row-url-value="<%= subscription_plan_path(subscription) %>">
-                <%# Service Column - Avatar + Name + Category (Clickable) %>
-                <td class="px-6 py-4" data-clickable-row-target="cell">
-                  <div class="flex items-center gap-3">
-                    <% if service&.respond_to?(:display_logo_url) && service.display_logo_url.present? %>
-                      <%= image_tag service.display_logo_url, class: "w-10 h-10 rounded-lg object-cover", loading: "lazy" %>
-                    <% else %>
-                      <div class="w-10 h-10 rounded-lg bg-gray-100 theme-dark:bg-gray-800 flex items-center justify-center text-xl">
-                        <%= service_icon(service) %>
-                      </div>
-                    <% end %>
-                    <div>
-                      <div class="font-medium text-primary group-hover:text-blue-600 theme-dark:group-hover:text-blue-400 transition-colors"><%= subscription.name %></div>
-                      <div class="text-xs text-secondary">
-                        <%= subscription_service_category(subscription)&.humanize || "Subscription" %>
-                        <% if subscription.shared_within_family %>
-                          <span class="ml-1 text-blue-600 theme-dark:text-blue-400">• Shared</span>
-                        <% end %>
-                      </div>
-                    </div>
-                  </div>
-                </td>
-
-                <%# Amount Column (Clickable) %>
-                <td class="px-6 py-4" data-clickable-row-target="cell">
-                  <div class="font-semibold text-primary"><%= number_to_currency(subscription.amount, unit: subscription.currency + " ") %></div>
-                  <div class="text-xs text-secondary"><%= subscription.billing_cycle.humanize %></div>
-                </td>
-
-                <%# Status Column (Clickable) %>
-                <td class="px-6 py-4" data-clickable-row-target="cell">
-                  <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium <%= subscription.status_badge_class %>">
-                    <%= subscription.status.humanize %>
-                  </span>
-                  <% if subscription.trial_days_remaining.positive? %>
-                    <div class="text-xs text-blue-600 theme-dark:text-blue-400 mt-1"><%= subscription.trial_days_remaining %>d trial</div>
-                  <% end %>
-                </td>
-
-                <%# Next Billing Column (Clickable) %>
-                <td class="px-6 py-4" data-clickable-row-target="cell">
-                  <% if subscription.next_billing_at %>
-                    <div class="text-sm text-primary"><%= subscription.next_billing_at.strftime("%b %d, %Y") %></div>
-                    <% if subscription.days_until_renewal == 0 %>
-                      <span class="text-xs font-medium text-orange-600 theme-dark:text-orange-400">Today</span>
-                    <% elsif subscription.days_until_renewal <= 3 %>
-                      <span class="text-xs font-medium text-red-600 theme-dark:text-red-400"><%= subscription.days_until_renewal %> days</span>
-                    <% else %>
-                      <span class="text-xs text-secondary"><%= subscription.days_until_renewal %> days</span>
-                    <% end %>
-                  <% else %>
-                    <span class="text-sm text-secondary">—</span>
-                  <% end %>
-                </td>
-
-                <%# Actions Column - Dropdown Menu (Not Clickable for row navigation) %>
-                <td class="px-6 py-4 text-right" data-clickable-row-target="exclude">
-                  <%= render DS::Menu.new(placement: "bottom-end") do |menu| %>
-                    <% menu.with_item(variant: "link", text: "View details", href: subscription_plan_path(subscription), icon: "eye") %>
-                    <% menu.with_item(variant: "link", text: "Edit", href: edit_subscription_plan_path(subscription), icon: "pencil", frame: "modal") %>
-
-                    <% if subscription.active_or_trial? %>
-                      <% menu.with_item(
-                        variant: "link",
-                        text: "Record payment",
-                        href: new_transaction_path(account_id: subscription.account_id, nature: "outflow", subscription_plan_id: subscription.id),
-                        icon: "credit-card",
-                        frame: "modal"
-                      ) %>
-                    <% end %>
-
-                    <% menu.with_item(variant: "divider") %>
-
-                    <% if subscription.active? %>
-                      <% menu.with_item(variant: "button", text: "Pause", href: pause_subscription_plan_path(subscription), icon: "pause", method: :patch) %>
-                    <% elsif subscription.paused? %>
-                      <% menu.with_item(variant: "button", text: "Resume", href: resume_subscription_plan_path(subscription), icon: "play", method: :patch) %>
-                    <% end %>
-
-                    <% menu.with_item(variant: "button", text: "Renew now", href: renew_subscription_plan_path(subscription), icon: "refresh-cw", method: :patch) %>
-
-                    <% menu.with_item(variant: "divider") %>
-
-                    <% if subscription.cancelled? || subscription.expired? %>
-                      <% menu.with_item(
-                        variant: "button",
-                        text: "Delete",
-                        href: subscription_plan_path(subscription),
-                        icon: "trash-2",
-                        method: :delete,
-                        destructive: true,
-                        confirm: "Are you sure you want to delete this subscription?"
-                      ) %>
-                    <% else %>
-                      <% menu.with_item(
-                        variant: "button",
-                        text: "Cancel subscription",
-                        href: cancel_subscription_plan_path(subscription),
-                        icon: "x-circle",
-                        method: :patch,
-                        destructive: true
-                      ) %>
-                    <% end %>
-                  <% end %>
-                </td>
-              </tr>
+              <%= render partial: "subscription_plans/row", locals: { subscription: subscription } %>
             <% end %>
           </tbody>
         </table>
@@ -228,10 +107,12 @@
         </div>
         <h3 class="text-lg font-medium text-primary mb-2">No Subscriptions Yet</h3>
         <p class="text-secondary mb-6 max-w-sm mx-auto">Start tracking your subscriptions and recurring payments to get insights.</p>
-        <%= link_to new_subscription_plan_path, class: "inline-flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors" do %>
-          <%= icon "plus", class: "h-5 w-5" %>
-          Add Your First Subscription
-        <% end %>
+        <%= render DS::Link.new(
+          text: "Add Your First Subscription",
+          icon: "plus",
+          variant: :primary,
+          href: new_subscription_plan_path
+        ) %>
       </div>
     <% end %>
   </div>

--- a/app/views/subscription_plans/show.html.erb
+++ b/app/views/subscription_plans/show.html.erb
@@ -21,53 +21,90 @@
       </div>
 
       <div class="flex items-center gap-2">
+        <% if @subscription_plan.active_or_trial? %>
+          <%= link_to new_subscription_plan_subscription_renewal_path(@subscription_plan),
+              data: { turbo_frame: "modal" },
+              class: "inline-flex min-h-10 items-center gap-2 rounded-full bg-primary px-5 py-2 font-semibold text-gray-900 shadow-border-xs transition-colors hover:bg-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+              title: "Record Payment" do %>
+            <%= icon "credit-card", class: "h-4 w-4" %>
+            Record Payment
+          <% end %>
+        <% end %>
+
         <%= link_to edit_subscription_plan_path(@subscription_plan), class: "inline-flex items-center gap-2 px-4 py-2 bg-container border border-primary rounded-lg hover:bg-gray-50 transition-colors" do %>
           <%= icon "edit", class: "h-4 w-4" %>
           Edit
         <% end %>
 
         <% if @subscription_plan.active? %>
-          <%= link_to pause_subscription_plan_path(@subscription_plan), method: :patch, class: "inline-flex items-center gap-2 px-4 py-2 bg-yellow-50 text-yellow-700 border border-yellow-200 theme-dark:bg-yellow-900/20 theme-dark:text-yellow-200 theme-dark:border-yellow-800 rounded-lg hover:bg-yellow-100 transition-colors" do %>
+          <%= link_to pause_subscription_plan_path(@subscription_plan), data: { turbo_method: :patch }, class: "inline-flex items-center gap-2 px-4 py-2 bg-yellow-50 text-yellow-700 border border-yellow-200 theme-dark:bg-yellow-900/20 theme-dark:text-yellow-200 theme-dark:border-yellow-800 rounded-lg hover:bg-yellow-100 transition-colors" do %>
             <%= icon "pause", class: "h-4 w-4" %>
             Pause
           <% end %>
         <% elsif @subscription_plan.paused? %>
-          <%= link_to resume_subscription_plan_path(@subscription_plan), method: :patch, class: "inline-flex items-center gap-2 px-4 py-2 bg-green-50 text-green-700 border border-green-200 theme-dark:bg-green-900/20 theme-dark:text-green-200 theme-dark:border-green-800 rounded-lg hover:bg-green-100 transition-colors" do %>
+          <%= link_to resume_subscription_plan_path(@subscription_plan), data: { turbo_method: :patch }, class: "inline-flex items-center gap-2 px-4 py-2 bg-green-50 text-green-700 border border-green-200 theme-dark:bg-green-900/20 theme-dark:text-green-200 theme-dark:border-green-800 rounded-lg hover:bg-green-100 transition-colors" do %>
             <%= icon "play", class: "h-4 w-4" %>
             Resume
           <% end %>
         <% end %>
 
         <% unless @subscription_plan.cancelled? || @subscription_plan.expired? %>
-          <%= link_to cancel_subscription_plan_path(@subscription_plan), method: :patch, data: { confirm: "Are you sure you want to cancel this subscription?" }, class: "inline-flex items-center gap-2 px-4 py-2 bg-red-50 text-red-700 border border-red-200 theme-dark:bg-red-900/30 theme-dark:text-red-300 theme-dark:border-red-800 rounded-lg hover:bg-red-100 transition-colors" do %>
-            <%= icon "x-circle", class: "h-4 w-4" %>
-            Cancel
+          <%= render DS::Menu.new(variant: "button", placement: "bottom-end") do |menu| %>
+            <% menu.with_button(
+              class: "inline-flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-red-700 transition-colors hover:bg-red-100 theme-dark:border-red-800 theme-dark:bg-red-900/30 theme-dark:text-red-300"
+            ) do %>
+              <%= icon "x-circle", class: "h-4 w-4" %>
+              Cancel
+              <%= icon "chevron-down", class: "h-4 w-4" %>
+            <% end %>
+
+            <% if @subscription_plan.pending_cancellation? %>
+              <% menu.with_item(
+                variant: "button",
+                text: "Keep subscription",
+                href: undo_cancellation_subscription_plan_path(@subscription_plan),
+                icon: "rotate-ccw",
+                method: :patch,
+                confirm: "Remove the scheduled cancellation and keep this subscription active?"
+              ) %>
+            <% else %>
+              <% menu.with_item(
+                variant: "button",
+                text: "Cancel at renewal",
+                href: cancel_subscription_plan_path(@subscription_plan, timing: "period_end"),
+                icon: "calendar-x",
+                method: :patch,
+                confirm: "Keep access until the next renewal, then cancel this subscription?"
+              ) %>
+            <% end %>
+            <% menu.with_item(
+              variant: "button",
+              text: "Cancel now",
+              href: cancel_subscription_plan_path(@subscription_plan, timing: "immediate"),
+              icon: "x-circle",
+              method: :patch,
+              destructive: true,
+              confirm: "Cancel immediately? Access and future billing may stop now."
+            ) %>
           <% end %>
         <% end %>
 
-        <% if @subscription_plan.active_or_trial? %>
-          <%= link_to new_transaction_path(
-                        account_id: @subscription_plan.account_id,
-                        nature: "outflow",
-                        subscription_plan_id: @subscription_plan.id
-                      ),
-                      class: "inline-flex items-center gap-2 px-4 py-2 bg-blue-50 text-blue-700 border border-blue-200 theme-dark:bg-blue-900/20 theme-dark:text-blue-200 theme-dark:border-blue-800 rounded-lg hover:bg-blue-100 transition-colors",
-                      data: {
-                        turbo_frame: :modal,
-                        turbo_confirm: "Record payment of #{number_to_currency(@subscription_plan.amount, unit: @subscription_plan.currency + ' ')} for #{@subscription_plan.name}?\n\nThis will advance billing to the next cycle if within payment window."
-                      } do %>
-            <%= icon "credit-card", class: "h-4 w-4" %>
-            Record payment
-          <% end %>
-        <% else %>
-          <span class="inline-flex items-center gap-2 px-4 py-2 bg-gray-100 text-gray-400 border border-gray-200 rounded-lg cursor-not-allowed theme-dark:bg-gray-800 theme-dark:text-gray-500 theme-dark:border-gray-700" title="Subscription is <%= @subscription_plan.status %>">
-            <%= icon "credit-card", class: "h-4 w-4" %>
-            Record payment
-          </span>
-        <% end %>
       </div>
     </div>
   </div>
+
+  <% if @subscription_plan.paused? %>
+    <div class="mb-6 flex items-start gap-3 rounded-[24px] border border-warning bg-yellow-tint-5 p-5 text-warning-content theme-dark:bg-yellow-tint-10">
+      <%= icon "shield-alert", class: "mt-0.5 h-5 w-5 shrink-0" %>
+      <div>
+        <p class="font-semibold">Renewal payments are paused</p>
+        <p class="mt-1 text-sm">
+          Record Payment is disabled for this lifecycle state. A matching charge imported or entered through Transactions
+          will be flagged as an unexpected renewal without resuming the subscription.
+        </p>
+      </div>
+    </div>
+  <% end %>
 
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
     <div class="lg:col-span-2 space-y-6">
@@ -100,6 +137,17 @@
           <div>
             <dt class="text-sm text-secondary">Billing Cycle</dt>
             <dd class="mt-1 text-primary"><%= @subscription_plan.formatted_billing_cycle %></dd>
+          </div>
+
+          <div>
+            <dt class="text-sm text-secondary">Reminder Policy</dt>
+            <dd class="mt-1 text-primary">
+              <% if @subscription_plan.trial? %>
+                Trial alerts 3, 2, and 1 days before expiry
+              <% else %>
+                Renewal alerts 3 and 1 days before billing
+              <% end %>
+            </dd>
           </div>
 
           <div>
@@ -192,6 +240,33 @@
           <p class="text-primary"><%= @subscription_plan.payment_notes %></p>
         </div>
       <% end %>
+
+      <div class="bg-container rounded-lg border border-primary p-6">
+        <h2 class="text-lg font-semibold text-primary mb-4">Payment History</h2>
+
+        <% if @entries.empty? %>
+          <div class="text-center py-8 bg-canvas-soft border border-dashed border-primary rounded-xl">
+            <%= icon "history", class: "h-8 w-8 text-secondary mx-auto mb-2" %>
+            <p class="text-sm font-medium text-primary">No Payment History Yet</p>
+            <p class="text-xs text-secondary mt-1">Payments recorded for this subscription will appear here.</p>
+          </div>
+        <% else %>
+          <div class="grid bg-container-inset rounded-xl grid-cols-12 items-center uppercase text-xs font-medium text-secondary px-5 py-3 mb-4">
+            <div class="pl-0.5 col-span-8 flex items-center gap-4">
+              <p>Date</p>
+            </div>
+            <p class="col-span-4 justify-self-end">Amount</p>
+          </div>
+
+          <div class="space-y-4">
+            <%= entries_by_date(@entries) do |entries| %>
+              <% entries.each_with_index do |entry, index| %>
+                <%= render entry, view_ctx: "account" %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
 
     <div class="space-y-6">
@@ -221,7 +296,11 @@
           <div>
             <div class="text-sm text-secondary">Yearly Cost</div>
             <div class="text-lg font-semibold text-primary">
-              <%= number_to_currency(@subscription_plan.yearly_equivalent_amount, unit: @subscription_plan.currency + " ") %>
+              <% if @subscription_plan.schedule.once? %>
+                Not recurring
+              <% else %>
+                <%= number_to_currency(@subscription_plan.yearly_equivalent_amount, unit: @subscription_plan.currency + " ") %>
+              <% end %>
             </div>
           </div>
         </div>
@@ -284,6 +363,34 @@
           </div>
         <% else %>
           <p class="text-secondary">No account linked</p>
+        <% end %>
+      </div>
+
+      <div class="bg-container rounded-lg border border-primary p-6">
+        <h2 class="text-lg font-semibold text-primary mb-4">Lifecycle Timeline</h2>
+
+        <% if @timeline_events.any? %>
+          <div class="space-y-4">
+            <% @timeline_events.each do |event| %>
+              <div class="flex items-start gap-3">
+                <span class="mt-1.5 h-2 w-2 shrink-0 rounded-full <%= event.changeset["severity"] == "warning" ? "bg-warning" : "bg-success" %>"></span>
+                <div>
+                  <p class="text-sm font-medium text-primary"><%= event.changeset["title"] || event.event.humanize %></p>
+                  <% if event.changeset["detail"].present? %>
+                    <p class="mt-1 text-xs text-secondary"><%= event.changeset["detail"] %></p>
+                  <% elsif event.event == "update" %>
+                    <p class="mt-1 text-xs text-secondary"><%= event.changeset.keys.map(&:humanize).to_sentence %> changed</p>
+                  <% end %>
+                  <p class="mt-1 text-xs text-secondary">
+                    <%= event.user_id.present? ? "User" : "System or provider" %>
+                    · <%= l(event.created_at, format: :short) %>
+                  </p>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <p class="text-sm text-secondary">Lifecycle changes and reconciliation events will appear here.</p>
         <% end %>
       </div>
     </div>

--- a/app/views/subscription_renewals/new.html.erb
+++ b/app/views/subscription_renewals/new.html.erb
@@ -1,0 +1,32 @@
+<%= render DS::Dialog.new(width: "md") do |dialog| %>
+  <% dialog.with_header(title: "Record Payment") %>
+
+  <% dialog.with_body do %>
+    <%= styled_form_with model: @renewal_form, url: subscription_plan_subscription_renewals_path(@subscription_plan), method: :post, id: "renewal-form", class: "space-y-4", data: { turbo: true } do |f| %>
+      <% if @renewal_form.errors.any? %>
+        <%= render "shared/form_errors", model: @renewal_form %>
+      <% end %>
+
+      <%= f.collection_select :account_id, @accounts, :id, :name, { label: "Payment Account", required: true } %>
+
+      <%= f.collection_select :category_id, @categories, :id, :name, { label: "Category", required: true } %>
+
+      <div class="flex items-center gap-3 py-1">
+        <%= f.toggle :update_default_account %>
+        <label for="subscription_plan_renewal_form_update_default_account" class="text-sm font-medium text-ink cursor-pointer select-none">
+          Set this account as permanent default for future bills
+        </label>
+      </div>
+
+      <div class="grid grid-cols-2 gap-4">
+        <%= f.money_field :actual_amount, label: "Amount", required: true, default_currency: @subscription_plan.currency, hide_currency: true %>
+        <%= f.money_field :admin_fee, label: "Admin Fee", default_currency: @subscription_plan.currency, hide_currency: true %>
+      </div>
+
+      <%= f.date_field :paid_at, label: "Date Paid", required: true %>
+    <% end %>
+  <% end %>
+
+  <% dialog.with_action(text: "Record Payment", variant: :primary, type: "submit", form: "renewal-form") %>
+  <% dialog.with_action(text: "Cancel", variant: :outline, cancel_action: true) %>
+<% end %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -2,7 +2,8 @@
 
 <div class="wise-form">
   <%= styled_form_with model: entry, url: transactions_path, class: "space-y-4", data: {
-        controller: "new-transaction-split",
+        controller: "new-transaction-split current-date",
+        current_date_timezone_value: Current.family.timezone.presence || Time.zone.name,
         "new_transaction_split_i18n_value": {
           name_label: t(".split_row_name_label"),
           name_placeholder: t(".split_row_name_placeholder"),
@@ -67,7 +68,8 @@
                              required: true,
                              min: Entry.min_supported_date,
                              max: Date.current,
-                             value: (entry.date || Date.current) %>
+                             value: (entry.date || Date.current),
+                             data: { current_date_target: "input" } %>
           </div>
         <% else %>
           <div class="form-field" data-controller="custom-select">
@@ -140,7 +142,8 @@
                              required: true,
                              min: Entry.min_supported_date,
                              max: Date.current,
-                             value: (entry.date || Date.current) %>
+                             value: (entry.date || Date.current),
+                             data: { current_date_target: "input" } %>
           </div>
         <% end %>
 
@@ -294,7 +297,7 @@
                         </button>
                       </div>
 
-                      <% [entry.entryable.merchant, *Current.family.merchants.alphabetically].compact.uniq.each do |merchant| %>
+                      <% [entry.entryable.merchant, *Current.family.available_transaction_merchants].compact.uniq.each do |merchant| %>
                         <div class="filterable-item flex items-center border-none rounded-lg px-2 py-1.5 group w-full hover:bg-container-inset-hover" data-filter-name="<%= merchant.name %>">
                           <button type="button"
                                   class="flex w-full items-center gap-2 cursor-pointer focus:outline-none"

--- a/app/views/transactions/bulk_updates/new.html.erb
+++ b/app/views/transactions/bulk_updates/new.html.erb
@@ -13,7 +13,7 @@
         <%= render DS::Disclosure.new(title: "Transactions", open: true) do %>
           <div class="space-y-2">
             <%= form.collection_select :category_id, Current.family.categories.alphabetically, :id, :name, { prompt: "Select a category", label: "Category", class: "text-subdued" } %>
-            <%= form.collection_select :merchant_id, Current.family.merchants.alphabetically, :id, :name, { prompt: "Select a merchant", label: "Merchant", class: "text-subdued" } %>
+            <%= form.collection_select :merchant_id, Current.family.available_transaction_merchants, :id, :name, { prompt: "Select a merchant", label: "Merchant", class: "text-subdued" } %>
             <%= form.select :tag_ids, Current.family.tags.alphabetically.pluck(:name, :id), { include_blank: "None", multiple: true, label: "Tags", container_class: "h-40" } %>
             <%= form.text_area :notes, label: "Notes", placeholder: "Enter a note that will be applied to selected transactions", rows: 5 %>
           </div>

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -20,7 +20,7 @@
                     <p class="text-sm font-medium text-primary"><%= potential_match.name %></p>
                     <p class="text-xs text-secondary"><%= potential_match.date.strftime("%b %d, %Y") %> • <%= potential_match.account.name %></p>
                   </div>
-                  <p class="text-sm font-medium <%= potential_match.amount.negative? ? 'text-green-600' : 'text-primary' %>">
+                  <p class="text-sm font-medium <%= potential_match.amount.negative? ? "text-green-600" : "text-primary" %>">
                     <%= format_money(-potential_match.amount_money) %>
                   </p>
                 </div>
@@ -113,7 +113,7 @@
             <%= f.fields_for :entryable do |ef| %>
 
               <%= ef.collection_select :merchant_id,
-                    [@entry.transaction.merchant, *Current.family.merchants.alphabetically].compact,
+                    [@entry.transaction.merchant, *Current.family.available_transaction_merchants].compact,
                     :id, :name,
                     { include_blank: t(".none"),
                       label: t(".merchant_label"),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,8 +51,9 @@ Rails.application.routes.draw do
       patch :pause
       patch :resume
       patch :cancel
-      patch :renew
+      patch :undo_cancellation
     end
+    resources :subscription_renewals, only: %i[index new create show]
   end
 
   # Services management

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -13,6 +13,12 @@ gold_price_fetch:
   queue: "scheduled"
   description: "Fetches daily Indonesian gold prices from harga-emas.org"
 
+subscription_renewals:
+  cron: "0 7 * * *"
+  class: "SubscriptionRenewalJob"
+  queue: "scheduled"
+  description: "Processes subscription lifecycle changes and sends renewal reminders"
+
 clean_syncs:
   cron: "0 * * * *" # every hour
   class: "SyncCleanerJob"

--- a/db/migrate/20260601082432_add_flexible_billing_to_subscription_plans.rb
+++ b/db/migrate/20260601082432_add_flexible_billing_to_subscription_plans.rb
@@ -1,0 +1,15 @@
+class AddFlexibleBillingToSubscriptionPlans < ActiveRecord::Migration[8.1]
+  def change
+    change_table :subscription_plans do |t|
+      t.integer  :billing_day_start
+      t.integer  :billing_day_end
+      t.decimal  :default_admin_fee, precision: 19, scale: 4, default: "0.0"
+      t.datetime :discarded_at
+    end
+
+    add_index :subscription_plans, :discarded_at,
+              name: "idx_sub_plans_discarded_at"
+    add_index :subscription_plans, [ :billing_day_start, :billing_day_end ],
+              name: "idx_sub_plans_billing_window"
+  end
+end

--- a/db/migrate/20260601082433_create_subscription_renewals.rb
+++ b/db/migrate/20260601082433_create_subscription_renewals.rb
@@ -1,0 +1,41 @@
+class CreateSubscriptionRenewals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :subscription_renewals, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.uuid    :subscription_plan_id, null: false
+      t.uuid    :account_id,           null: false
+      t.uuid    :entry_id
+      t.integer :cycle_number,         null: false, default: 1
+      t.date    :billing_period_start, null: false
+      t.date    :billing_period_end,   null: false
+      t.date    :paid_at
+      t.decimal :template_amount,      null: false, precision: 19, scale: 4
+      t.decimal :actual_amount,        null: false, precision: 19, scale: 4
+      t.decimal :admin_fee,            precision: 19, scale: 4, default: "0.0"
+      t.virtual :total_paid,           type: :decimal, precision: 19, scale: 4,
+                as: "actual_amount + COALESCE(admin_fee, 0)", stored: true
+      t.string  :currency,             null: false, limit: 3
+      t.string  :status,               null: false, default: "pending"
+      t.string  :payment_method
+      t.text    :notes
+      t.jsonb   :metadata,             default: {}
+      t.timestamps
+    end
+
+    add_foreign_key :subscription_renewals, :subscription_plans, on_delete: :cascade
+    add_foreign_key :subscription_renewals, :accounts
+    add_foreign_key :subscription_renewals, :entries, on_delete: :nullify
+
+    add_index :subscription_renewals, :subscription_plan_id,
+              name: "idx_sub_renewals_plan_id"
+    add_index :subscription_renewals, :account_id,
+              name: "idx_sub_renewals_account_id"
+    add_index :subscription_renewals, :entry_id,
+              name: "idx_sub_renewals_entry_id"
+    add_index :subscription_renewals, [ :subscription_plan_id, :cycle_number ],
+              unique: true,
+              name: "idx_sub_renewals_plan_cycle_unique"
+    add_index :subscription_renewals, [ :subscription_plan_id, :status ],
+              name: "idx_sub_renewals_plan_status"
+    add_index :subscription_renewals, :paid_at
+  end
+end

--- a/db/migrate/20260601082434_fix_negative_subscription_renewal_entries.rb
+++ b/db/migrate/20260601082434_fix_negative_subscription_renewal_entries.rb
@@ -1,0 +1,17 @@
+class FixNegativeSubscriptionRenewalEntries < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL
+      UPDATE entries
+      SET amount = ABS(entries.amount),
+          updated_at = CURRENT_TIMESTAMP
+      FROM subscription_renewals
+      WHERE subscription_renewals.entry_id = entries.id
+        AND subscription_renewals.status = 'paid'
+        AND entries.amount < 0
+    SQL
+  end
+
+  def down
+    # Positive expense magnitudes are the canonical representation.
+  end
+end

--- a/db/migrate/20260606000200_add_stripe_lifecycle_to_subscription_plans.rb
+++ b/db/migrate/20260606000200_add_stripe_lifecycle_to_subscription_plans.rb
@@ -1,0 +1,11 @@
+class AddStripeLifecycleToSubscriptionPlans < ActiveRecord::Migration[8.1]
+  def change
+    add_column :subscription_plans, :cancel_at_period_end, :boolean, default: false, null: false
+    add_column :subscription_plans, :stripe_cancel_at, :datetime
+    add_column :subscription_plans, :stripe_current_period_end, :datetime
+    add_column :subscription_plans, :stripe_status, :string
+
+    add_index :subscription_plans, :stripe_status
+    add_index :subscription_plans, :cancel_at_period_end
+  end
+end

--- a/db/migrate/20260606000400_add_stripe_event_tracking.rb
+++ b/db/migrate/20260606000400_add_stripe_event_tracking.rb
@@ -1,0 +1,19 @@
+class AddStripeEventTracking < ActiveRecord::Migration[8.1]
+  def change
+    add_column :subscription_plans, :stripe_last_event_created_at, :datetime
+    add_column :subscription_plans, :stripe_last_event_id, :string
+
+    create_table :stripe_event_receipts, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.references :subscription_plan, type: :uuid, foreign_key: { on_delete: :cascade }
+      t.string :event_id, null: false
+      t.string :event_type, null: false
+      t.datetime :event_created_at, null: false
+      t.string :status, null: false, default: "processed"
+      t.timestamps
+    end
+
+    add_index :stripe_event_receipts, :event_id, unique: true
+    add_index :stripe_event_receipts, [ :subscription_plan_id, :event_created_at ],
+      name: "idx_stripe_receipts_plan_created"
+  end
+end

--- a/db/migrate/20260606000500_scope_custom_service_merchants_to_families.rb
+++ b/db/migrate/20260606000500_scope_custom_service_merchants_to_families.rb
@@ -1,0 +1,90 @@
+class ScopeCustomServiceMerchantsToFamilies < ActiveRecord::Migration[8.1]
+  INDEX_NAME = "idx_service_merchants_family_name_unique".freeze
+
+  def up
+    execute <<~SQL
+      DO $$
+      DECLARE
+        service_record RECORD;
+        family_record RECORD;
+        scoped_service_id uuid;
+      BEGIN
+        FOR service_record IN
+          SELECT *
+          FROM merchants
+          WHERE type = 'ServiceMerchant'
+            AND family_id IS NULL
+            AND COALESCE(popular, false) = false
+        LOOP
+          FOR family_record IN
+            SELECT DISTINCT family_id
+            FROM subscription_plans
+            WHERE merchant_id = service_record.id
+          LOOP
+            SELECT id
+            INTO scoped_service_id
+            FROM merchants
+            WHERE type = 'ServiceMerchant'
+              AND family_id = family_record.family_id
+              AND name = service_record.name
+            LIMIT 1;
+
+            IF scoped_service_id IS NULL THEN
+              scoped_service_id := gen_random_uuid();
+
+              INSERT INTO merchants (
+                id,
+                avg_monthly_cost,
+                billing_frequency,
+                color,
+                created_at,
+                description,
+                family_id,
+                logo_url,
+                name,
+                popular,
+                subscription_category,
+                support_email,
+                type,
+                updated_at,
+                website_url
+              ) VALUES (
+                scoped_service_id,
+                service_record.avg_monthly_cost,
+                service_record.billing_frequency,
+                service_record.color,
+                service_record.created_at,
+                service_record.description,
+                family_record.family_id,
+                service_record.logo_url,
+                service_record.name,
+                false,
+                service_record.subscription_category,
+                service_record.support_email,
+                service_record.type,
+                service_record.updated_at,
+                service_record.website_url
+              );
+            END IF;
+
+            UPDATE subscription_plans
+            SET merchant_id = scoped_service_id
+            WHERE merchant_id = service_record.id
+              AND family_id = family_record.family_id;
+          END LOOP;
+        END LOOP;
+      END
+      $$;
+    SQL
+
+    add_index :merchants,
+      [ :family_id, :name ],
+      unique: true,
+      where: "type = 'ServiceMerchant' AND family_id IS NOT NULL",
+      name: INDEX_NAME
+  end
+
+  def down
+    remove_index :merchants, name: INDEX_NAME, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_01_082431) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_06_000500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -738,6 +738,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_082431) do
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.string "website_url"
+    t.index ["family_id", "name"], name: "idx_service_merchants_family_name_unique", unique: true, where: "(((type)::text = 'ServiceMerchant'::text) AND (family_id IS NOT NULL))"
     t.index ["family_id", "name"], name: "index_merchants_on_family_id_and_name", unique: true, where: "((type)::text = 'FamilyMerchant'::text)"
     t.index ["family_id"], name: "index_merchants_on_family_id"
     t.index ["popular"], name: "index_merchants_on_popular"
@@ -1225,16 +1226,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_082431) do
     t.index ["status"], name: "index_simplefin_items_on_status"
   end
 
+  create_table "stripe_event_receipts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "event_created_at", null: false
+    t.string "event_id", null: false
+    t.string "event_type", null: false
+    t.string "status", default: "processed", null: false
+    t.uuid "subscription_plan_id"
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_stripe_event_receipts_on_event_id", unique: true
+    t.index ["subscription_plan_id", "event_created_at"], name: "idx_stripe_receipts_plan_created"
+    t.index ["subscription_plan_id"], name: "index_stripe_event_receipts_on_subscription_plan_id"
+  end
+
   create_table "subscription_plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
     t.decimal "amount", precision: 19, scale: 4, null: false
     t.boolean "archived", default: false, null: false
     t.boolean "auto_renew", default: true, null: false
     t.string "billing_cycle", default: "monthly", null: false
+    t.integer "billing_day_end"
+    t.integer "billing_day_start"
+    t.boolean "cancel_at_period_end", default: false, null: false
     t.date "cancelled_at"
     t.datetime "created_at", null: false
     t.string "currency", default: "USD", null: false
+    t.decimal "default_admin_fee", precision: 19, scale: 4, default: "0.0"
     t.text "description"
+    t.datetime "discarded_at"
     t.date "expires_at"
     t.boolean "failed_payment_alert_sent", default: false, null: false
     t.uuid "family_id", null: false
@@ -1250,13 +1269,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_082431) do
     t.boolean "shared_within_family", default: false, null: false
     t.date "started_at", null: false
     t.string "status", default: "active", null: false
+    t.datetime "stripe_cancel_at"
+    t.datetime "stripe_current_period_end"
     t.string "stripe_customer_id"
+    t.datetime "stripe_last_event_created_at"
+    t.string "stripe_last_event_id"
+    t.string "stripe_status"
     t.string "stripe_subscription_id"
     t.date "trial_ends_at"
     t.datetime "updated_at", null: false
     t.integer "usage_count", default: 0
     t.index ["account_id"], name: "index_subscription_plans_on_account_id"
     t.index ["archived"], name: "index_subscription_plans_on_archived"
+    t.index ["billing_day_start", "billing_day_end"], name: "idx_sub_plans_billing_window"
+    t.index ["cancel_at_period_end"], name: "index_subscription_plans_on_cancel_at_period_end"
+    t.index ["discarded_at"], name: "idx_sub_plans_discarded_at"
     t.index ["family_id", "next_billing_at"], name: "index_subscription_plans_on_family_id_and_next_billing_at"
     t.index ["family_id", "service_id"], name: "index_subscription_plans_on_family_id_and_service_id", unique: true
     t.index ["family_id", "status"], name: "index_subscription_plans_on_family_id_and_status"
@@ -1264,7 +1291,35 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_082431) do
     t.index ["merchant_id"], name: "index_subscription_plans_on_merchant_id"
     t.index ["service_id"], name: "index_subscription_plans_on_service_id"
     t.index ["status", "next_billing_at"], name: "index_subscription_plans_on_status_and_next_billing_at"
+    t.index ["stripe_status"], name: "index_subscription_plans_on_stripe_status"
     t.index ["stripe_subscription_id"], name: "index_subscription_plans_on_stripe_subscription_id", unique: true, where: "(stripe_subscription_id IS NOT NULL)"
+  end
+
+  create_table "subscription_renewals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.decimal "actual_amount", precision: 19, scale: 4, null: false
+    t.decimal "admin_fee", precision: 19, scale: 4, default: "0.0"
+    t.date "billing_period_end", null: false
+    t.date "billing_period_start", null: false
+    t.datetime "created_at", null: false
+    t.string "currency", limit: 3, null: false
+    t.integer "cycle_number", default: 1, null: false
+    t.uuid "entry_id"
+    t.jsonb "metadata", default: {}
+    t.text "notes"
+    t.date "paid_at"
+    t.string "payment_method"
+    t.string "status", default: "pending", null: false
+    t.uuid "subscription_plan_id", null: false
+    t.decimal "template_amount", precision: 19, scale: 4, null: false
+    t.virtual "total_paid", type: :decimal, precision: 19, scale: 4, as: "(actual_amount + COALESCE(admin_fee, (0)::numeric))", stored: true
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "idx_sub_renewals_account_id"
+    t.index ["entry_id"], name: "idx_sub_renewals_entry_id"
+    t.index ["paid_at"], name: "index_subscription_renewals_on_paid_at"
+    t.index ["subscription_plan_id", "cycle_number"], name: "idx_sub_renewals_plan_cycle_unique", unique: true
+    t.index ["subscription_plan_id", "status"], name: "idx_sub_renewals_plan_status"
+    t.index ["subscription_plan_id"], name: "idx_sub_renewals_plan_id"
   end
 
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1498,10 +1553,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_01_082431) do
   add_foreign_key "sessions", "users"
   add_foreign_key "simplefin_accounts", "simplefin_items"
   add_foreign_key "simplefin_items", "families"
+  add_foreign_key "stripe_event_receipts", "subscription_plans", on_delete: :cascade
   add_foreign_key "subscription_plans", "accounts"
   add_foreign_key "subscription_plans", "families"
   add_foreign_key "subscription_plans", "merchants", on_delete: :nullify
   add_foreign_key "subscription_plans", "services"
+  add_foreign_key "subscription_renewals", "accounts"
+  add_foreign_key "subscription_renewals", "entries", on_delete: :nullify
+  add_foreign_key "subscription_renewals", "subscription_plans", on_delete: :cascade
   add_foreign_key "subscriptions", "families"
   add_foreign_key "syncs", "syncs", column: "parent_id"
   add_foreign_key "taggings", "tags"

--- a/test/controllers/services_controller_test.rb
+++ b/test/controllers/services_controller_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class ServicesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    @family = @user.family
+    @other_family = families(:empty)
+    sign_in @user
+  end
+
+  test "index only exposes catalog and current family services" do
+    catalog_service = create_service(name: "Catalog Visible", popular: true)
+    family_service = create_service(name: "Family Visible", family: @family)
+    other_service = create_service(name: "Other Family Hidden", family: @other_family)
+
+    get services_url
+
+    assert_response :success
+    assert_select "[data-service-id='#{catalog_service.id}']"
+    assert_select "[data-service-id='#{family_service.id}']"
+    assert_select "[data-service-id='#{other_service.id}']", count: 0
+  end
+
+  test "create assigns the service to the current family" do
+    assert_difference -> { ServiceMerchant.owned_by(@family).count }, 1 do
+      post services_url, params: {
+        service_merchant: {
+          name: "Private Service",
+          subscription_category: "software"
+        }
+      }
+    end
+
+    assert_redirected_to services_url
+    assert_equal @family, ServiceMerchant.find_by!(name: "Private Service").family
+  end
+
+  test "cannot edit another family service" do
+    other_service = create_service(name: "Other Family Protected", family: @other_family)
+
+    get edit_service_url(other_service)
+
+    assert_response :not_found
+  end
+
+  private
+
+    def create_service(name:, family: nil, popular: false)
+      ServiceMerchant.create!(
+        name: name,
+        subscription_category: "software",
+        family: family,
+        popular: popular
+      )
+    end
+end

--- a/test/controllers/subscription_plans_controller_test.rb
+++ b/test/controllers/subscription_plans_controller_test.rb
@@ -9,6 +9,42 @@ class SubscriptionPlansControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
     get subscription_plans_url
     assert_response :success
+    assert_select "a[href='#{new_subscription_plan_path}'].bg-primary.text-on-primary", text: /Add Subscription/
+  end
+
+  test "index edit action uses full page navigation" do
+    get subscription_plans_url
+
+    assert_response :success
+    assert_select "a[href='#{edit_subscription_plan_path(@subscription_plan)}']", minimum: 1
+    assert_select "a[href='#{edit_subscription_plan_path(@subscription_plan)}'][data-turbo-frame='modal']", count: 0
+  end
+
+  test "index renders destructive menu confirmation for cancelled subscriptions" do
+    @subscription_plan.update!(status: "cancelled")
+
+    get subscription_plans_url
+    assert_response :success
+
+    row_id = ActionView::RecordIdentifier.dom_id(@subscription_plan, :row)
+    assert_select "tr##{row_id}" do
+      assert_select "[data-subscription-status='cancelled']", text: /Cancelled/
+      assert_select "[data-subscription-billing-state]", text: /Ended/
+    end
+    assert_select "[data-turbo-confirm='Are you sure you want to delete this subscription?']"
+  end
+
+  test "index renders paused lifecycle separately from billing state" do
+    @subscription_plan.update!(status: "paused")
+
+    get subscription_plans_url
+    assert_response :success
+
+    row_id = ActionView::RecordIdentifier.dom_id(@subscription_plan, :row)
+    assert_select "tr##{row_id}" do
+      assert_select "[data-subscription-status='paused']", text: /Paused/
+      assert_select "[data-subscription-billing-state]", text: /Renewal paused/
+    end
   end
 
   test "should get show" do
@@ -16,9 +52,55 @@ class SubscriptionPlansControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show exposes record payment for active subscriptions" do
+    get subscription_plan_url(@subscription_plan)
+
+    assert_response :success
+    assert_select "a[href='#{new_subscription_plan_subscription_renewal_path(@subscription_plan)}'][data-turbo-frame='modal']", text: /Record Payment/
+  end
+
+  test "show hides record payment for paused subscriptions" do
+    @subscription_plan.update!(status: "paused")
+
+    get subscription_plan_url(@subscription_plan)
+
+    assert_response :success
+    assert_select "a[href='#{new_subscription_plan_subscription_renewal_path(@subscription_plan)}']", count: 0
+    assert_select "p", text: /matching charge.*unexpected renewal/i
+  end
+
+  test "show renders turbo patch lifecycle actions" do
+    get subscription_plan_url(@subscription_plan)
+    assert_response :success
+
+    assert_select "a[href='#{pause_subscription_plan_path(@subscription_plan)}'][data-turbo-method='patch']", text: /Pause/
+    assert_select "form[action='#{cancel_subscription_plan_path(@subscription_plan, timing: "period_end")}']" do
+      assert_select "button[data-turbo-confirm]", text: /Cancel at renewal/
+    end
+    assert_select "form[action='#{cancel_subscription_plan_path(@subscription_plan, timing: "immediate")}']" do
+      assert_select "button[data-turbo-confirm]", text: /Cancel now/
+    end
+    assert_select "a[data-method='patch']", count: 0
+  end
+
+  test "show renders turbo patch resume action when paused" do
+    @subscription_plan.update!(status: "paused")
+
+    get subscription_plan_url(@subscription_plan)
+    assert_response :success
+
+    assert_select "a[href='#{resume_subscription_plan_path(@subscription_plan)}'][data-turbo-method='patch']", text: /Resume/
+    assert_select "a[data-method='patch']", count: 0
+  end
+
   test "should get new" do
     get new_subscription_plan_url
     assert_response :success
+    assert_select "[data-controller~='subscription-schedule']"
+    assert_select "[data-subscription-schedule-target='count']"
+    assert_select "[data-subscription-schedule-target='unit']"
+    assert_select "[data-subscription-schedule-target='start']"
+    assert_select "[data-subscription-schedule-target='next']"
   end
 
   test "should get edit" do
@@ -63,6 +145,20 @@ class SubscriptionPlansControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated Netflix", @subscription_plan.name
   end
 
+  test "updates a flexible billing schedule" do
+    patch subscription_plan_url(@subscription_plan), params: {
+      subscription_plan: {
+        interval_count: 2,
+        interval_unit: "week"
+      }
+    }
+
+    assert_redirected_to subscription_plans_url
+    @subscription_plan.reload
+    assert_equal({ "count" => 2, "unit" => "week" }, @subscription_plan.metadata["schedule"])
+    assert_equal "Every 2 weeks", @subscription_plan.formatted_billing_cycle
+  end
+
   test "should archive subscription plan on destroy" do
     delete subscription_plan_url(@subscription_plan)
     assert_redirected_to subscription_plans_url
@@ -92,11 +188,46 @@ class SubscriptionPlansControllerTest < ActionDispatch::IntegrationTest
     assert_equal "cancelled", @subscription_plan.status
   end
 
-  test "should renew subscription plan" do
-    original_next_billing = @subscription_plan.next_billing_at
-    patch renew_subscription_plan_url(@subscription_plan)
+  test "should schedule cancellation at next renewal" do
+    patch cancel_subscription_plan_url(@subscription_plan), params: { timing: "period_end" }
+
     assert_redirected_to subscription_plans_url
     @subscription_plan.reload
-    assert @subscription_plan.next_billing_at > original_next_billing
+    assert_equal "active", @subscription_plan.status
+    assert @subscription_plan.pending_cancellation?
+    assert_not @subscription_plan.auto_renew
+  end
+
+  test "index exposes immediate and period end cancellation choices" do
+    get subscription_plans_url
+
+    assert_response :success
+    assert_select "form[action='#{cancel_subscription_plan_path(@subscription_plan, timing: "period_end")}']" do
+      assert_select "button", text: /Cancel at renewal/
+    end
+    assert_select "form[action='#{cancel_subscription_plan_path(@subscription_plan, timing: "immediate")}']" do
+      assert_select "button", text: /Cancel now/
+    end
+  end
+
+  test "undoes scheduled cancellation" do
+    @subscription_plan.update!(cancel_at_period_end: true, auto_renew: false)
+
+    patch undo_cancellation_subscription_plan_url(@subscription_plan)
+
+    assert_redirected_to subscription_plans_url
+    assert_not @subscription_plan.reload.cancel_at_period_end
+    assert @subscription_plan.auto_renew
+  end
+
+  test "index exposes keep subscription for pending cancellation" do
+    @subscription_plan.update!(cancel_at_period_end: true, auto_renew: false)
+
+    get subscription_plans_url
+
+    assert_response :success
+    assert_select "form[action='#{undo_cancellation_subscription_plan_path(@subscription_plan)}']" do
+      assert_select "button", text: /Keep subscription/
+    end
   end
 end

--- a/test/controllers/subscription_renewals_controller_test.rb
+++ b/test/controllers/subscription_renewals_controller_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class SubscriptionRenewalsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+    sign_in @user
+    @subscription_plan = subscription_plans(:netflix_subscription)
+    @account = accounts(:depository)
+    @category = categories(:food_and_drink)
+  end
+
+  test "should get index" do
+    get subscription_plan_subscription_renewals_url(@subscription_plan)
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_subscription_plan_subscription_renewal_url(@subscription_plan)
+    assert_response :success
+  end
+
+  test "should reject recording a payment for a paused subscription" do
+    @subscription_plan.update!(status: "paused")
+
+    get new_subscription_plan_subscription_renewal_url(@subscription_plan)
+
+    assert_redirected_to subscription_plan_path(@subscription_plan)
+    assert_equal "Payments can only be recorded for active or trial subscriptions.", flash[:alert]
+  end
+
+  test "should create subscription renewal via HTML redirect" do
+    assert_difference -> { @subscription_plan.subscription_renewals.count } => 1, -> { Entry.count } => 1 do
+      post subscription_plan_subscription_renewals_url(@subscription_plan), params: {
+        subscription_plan_renewal_form: {
+          account_id: @account.id,
+          actual_amount: 22.99,
+          admin_fee: 0,
+          paid_at: Date.current,
+          update_default_account: "0",
+          category_id: @category.id
+        }
+      }
+    end
+    assert_redirected_to subscription_plans_path
+    assert_equal "Payment recorded successfully!", flash[:notice]
+  end
+
+  test "should create subscription renewal via Turbo Stream" do
+    assert_difference -> { @subscription_plan.subscription_renewals.count } => 1, -> { Entry.count } => 1 do
+      post subscription_plan_subscription_renewals_url(@subscription_plan), as: :turbo_stream, params: {
+        subscription_plan_renewal_form: {
+          account_id: @account.id,
+          actual_amount: 22.99,
+          admin_fee: 0,
+          paid_at: Date.current,
+          update_default_account: "0",
+          category_id: @category.id
+        }
+      }
+    end
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+  end
+
+  test "should not create with invalid params" do
+    assert_no_difference -> { @subscription_plan.subscription_renewals.count } do
+      post subscription_plan_subscription_renewals_url(@subscription_plan), params: {
+        subscription_plan_renewal_form: {
+          account_id: @account.id,
+          actual_amount: 0, # invalid
+          paid_at: Date.current,
+          category_id: @category.id
+        }
+      }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "should not create with category from another family" do
+    assert_no_difference -> { @subscription_plan.subscription_renewals.count } do
+      post subscription_plan_subscription_renewals_url(@subscription_plan), params: {
+        subscription_plan_renewal_form: {
+          account_id: @account.id,
+          actual_amount: 22.99,
+          paid_at: Date.current,
+          category_id: categories(:one).id
+        }
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -131,29 +131,34 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     original_next_billing = subscription.next_billing_at
     original_usage_count = subscription.usage_count || 0
 
-    post transactions_url, params: {
-      subscription_plan_id: subscription.id,
-      entry: {
-        account_id: account.id,
-        name: "Subscription payment",
-        date: Date.current,
-        currency: subscription.currency,
-        amount: subscription.amount,
-        nature: "outflow",
-        entryable_type: @entry.entryable_type,
-        entryable_attributes: {
-          tag_ids: [],
-          category_id: Category.first.id,
-          merchant_id: Merchant.first.id
+    assert_difference "SubscriptionRenewal.count", 1 do
+      post transactions_url, params: {
+        subscription_plan_id: subscription.id,
+        entry: {
+          account_id: account.id,
+          name: "Subscription payment",
+          date: Date.current,
+          currency: subscription.currency,
+          amount: subscription.amount,
+          nature: "outflow",
+          entryable_type: @entry.entryable_type,
+          entryable_attributes: {
+            tag_ids: [],
+            category_id: Category.first.id,
+            merchant_id: Merchant.first.id
+          }
         }
       }
-    }
+    end
 
     subscription.reload
+    renewal = subscription.subscription_renewals.last
 
     # Verify billing was advanced
     assert_equal original_next_billing.next_month, subscription.next_billing_at, "Billing date should advance"
     assert_equal original_usage_count + 1, subscription.usage_count, "Usage count should increment"
+    assert_equal "paid", renewal.status
+    assert_equal Entry.order(:created_at).last, renewal.entry
 
     # Flash should include subscription name and new billing date
     assert_includes flash[:notice], subscription.name
@@ -167,24 +172,26 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
 
     too_large_amount = subscription.amount * 2
 
-    assert_difference [ "Entry.count", "Transaction.count" ], 1 do
-      post transactions_url, params: {
-        subscription_plan_id: subscription.id,
-        entry: {
-          account_id: account.id,
-          name: "Spotify oversized payment",
-          date: Date.current,
-          currency: subscription.currency,
-          amount: too_large_amount,
-          nature: "outflow",
-          entryable_type: @entry.entryable_type,
-          entryable_attributes: {
-            tag_ids: [],
-            category_id: Category.first.id,
-            merchant_id: merchants(:netflix).id
+    assert_no_difference "SubscriptionRenewal.count" do
+      assert_difference [ "Entry.count", "Transaction.count" ], 1 do
+        post transactions_url, params: {
+          subscription_plan_id: subscription.id,
+          entry: {
+            account_id: account.id,
+            name: "Spotify oversized payment",
+            date: Date.current,
+            currency: subscription.currency,
+            amount: too_large_amount,
+            nature: "outflow",
+            entryable_type: @entry.entryable_type,
+            entryable_attributes: {
+              tag_ids: [],
+              category_id: Category.first.id,
+              merchant_id: merchants(:netflix).id
+            }
           }
         }
-      }
+      end
     end
 
     subscription.reload
@@ -196,24 +203,26 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     account = subscription.account
     original_next_billing = subscription.next_billing_at
 
-    assert_difference [ "Entry.count", "Transaction.count" ], 1 do
-      post transactions_url, params: {
-        subscription_plan_id: subscription.id,
-        entry: {
-          account_id: account.id,
-          name: "Spotify wrong currency",
-          date: Date.current,
-          currency: "EUR",
-          amount: subscription.amount,
-          nature: "outflow",
-          entryable_type: @entry.entryable_type,
-          entryable_attributes: {
-            tag_ids: [],
-            category_id: Category.first.id,
-            merchant_id: merchants(:netflix).id
+    assert_no_difference "SubscriptionRenewal.count" do
+      assert_difference [ "Entry.count", "Transaction.count" ], 1 do
+        post transactions_url, params: {
+          subscription_plan_id: subscription.id,
+          entry: {
+            account_id: account.id,
+            name: "Spotify wrong currency",
+            date: Date.current,
+            currency: "EUR",
+            amount: subscription.amount,
+            nature: "outflow",
+            entryable_type: @entry.entryable_type,
+            entryable_attributes: {
+              tag_ids: [],
+              category_id: Category.first.id,
+              merchant_id: merchants(:netflix).id
+            }
           }
         }
-      }
+      end
     end
 
     subscription.reload
@@ -225,24 +234,26 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
     other_account = accounts(:depository)
     original_next_billing = subscription.next_billing_at
 
-    assert_difference [ "Entry.count", "Transaction.count" ], 1 do
-      post transactions_url, params: {
-        subscription_plan_id: subscription.id,
-        entry: {
-          account_id: other_account.id,
-          name: "Spotify wrong account",
-          date: Date.current,
-          currency: subscription.currency,
-          amount: subscription.amount,
-          nature: "outflow",
-          entryable_type: @entry.entryable_type,
-          entryable_attributes: {
-            tag_ids: [],
-            category_id: Category.first.id,
-            merchant_id: merchants(:netflix).id
+    assert_no_difference "SubscriptionRenewal.count" do
+      assert_difference [ "Entry.count", "Transaction.count" ], 1 do
+        post transactions_url, params: {
+          subscription_plan_id: subscription.id,
+          entry: {
+            account_id: other_account.id,
+            name: "Spotify wrong account",
+            date: Date.current,
+            currency: subscription.currency,
+            amount: subscription.amount,
+            nature: "outflow",
+            entryable_type: @entry.entryable_type,
+            entryable_attributes: {
+              tag_ids: [],
+              category_id: Category.first.id,
+              merchant_id: merchants(:netflix).id
+            }
           }
         }
-      }
+      end
     end
 
     subscription.reload

--- a/test/jobs/subscription_renewal_job_test.rb
+++ b/test/jobs/subscription_renewal_job_test.rb
@@ -1,7 +1,54 @@
 require "test_helper"
 
 class SubscriptionRenewalJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @subscription_plan = subscription_plans(:netflix_subscription)
+    @subscription_plan.subscription_renewals.destroy_all
+    @job = SubscriptionRenewalJob.new
+  end
+
+  test "creates stripe renewal through entry transaction pipeline" do
+    invoice = Struct.new(:id).new("in_test_123")
+    stripe_subscription = Struct.new(:latest_invoice).new(invoice)
+    billing_period_start = @subscription_plan.next_billing_at
+    billing_period_end = @subscription_plan.calculate_next_billing_date
+
+    assert_difference -> { Entry.count } => 1, -> { Transaction.count } => 1, -> { @subscription_plan.subscription_renewals.count } => 1 do
+      @job.send(
+        :create_stripe_transaction,
+        @subscription_plan,
+        stripe_subscription,
+        billing_period_start: billing_period_start,
+        billing_period_end: billing_period_end
+      )
+    end
+
+    renewal = @subscription_plan.subscription_renewals.last
+    entry = renewal.entry
+
+    assert_equal @subscription_plan.account, entry.account
+    assert_equal "Subscription: #{@subscription_plan.name}", entry.name
+    assert_equal @subscription_plan.amount, entry.amount
+    assert_equal @subscription_plan.currency, entry.currency
+    assert_equal "paid", renewal.status
+    assert_equal billing_period_start, renewal.billing_period_start
+    assert_equal billing_period_end, renewal.billing_period_end
+    assert_equal "in_test_123", entry.entryable.extra["stripe_invoice_id"]
+  end
+
+  test "processes manual renewal without Current family context" do
+    Current.reset
+    subscription = subscription_plans(:spotify_subscription)
+    subscription.subscription_renewals.destroy_all
+    renewal_date = subscription.next_billing_at
+
+    assert_difference -> { Entry.count } => 1, -> { Transaction.count } => 1, -> { subscription.subscription_renewals.count } => 1 do
+      @job.send(:process_subscription_renewal, subscription, renewal_date)
+    end
+
+    renewal = subscription.subscription_renewals.last
+    assert_equal "paid", renewal.status
+    assert_equal renewal_date, renewal.paid_at
+    assert_equal renewal_date.next_month, subscription.reload.next_billing_at
+  end
 end

--- a/test/mailers/subscription_mailer_test.rb
+++ b/test/mailers/subscription_mailer_test.rb
@@ -1,7 +1,27 @@
 require "test_helper"
 
 class SubscriptionMailerTest < ActionMailer::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "trial ending renders the milestone and subscription link" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(status: "trial", trial_ends_at: 2.days.from_now.to_date)
+
+    mail = SubscriptionMailer.trial_ending(subscription, 2)
+
+    assert_equal [ subscription.family.primary_user.email ], mail.to
+    assert_match "trial ends in 2 days", mail.subject
+    assert_match "2 days", mail.body.encoded
+    assert_match "/subscription_plans/#{subscription.id}", mail.body.encoded
+  end
+
+  test "trial expired renders the lifecycle notice" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(status: "trial", trial_ends_at: Date.current)
+
+    mail = SubscriptionMailer.trial_expired(subscription)
+
+    assert_equal [ subscription.family.primary_user.email ], mail.to
+    assert_match "trial has expired", mail.subject
+    assert_match "Subscription Manager", mail.body.encoded
+    assert_match "/subscription_plans/#{subscription.id}", mail.body.encoded
+  end
 end

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -1,6 +1,25 @@
 require "test_helper"
 
 class FamilyTest < ActiveSupport::TestCase
+  test "primary user prefers an active administrator" do
+    family = families(:dylan_family)
+
+    assert family.primary_user.active?
+    assert family.primary_user.admin?
+  end
+
+  test "available transaction merchants include services used by subscriptions" do
+    family = families(:dylan_family)
+    service = ServiceMerchant.create!(
+      name: "Family Subscription Merchant",
+      subscription_category: "software"
+    )
+    subscription_plans(:netflix_subscription).update!(merchant: service)
+
+    assert_includes family.available_transaction_merchants, service
+    assert_includes family.available_transaction_merchants, family.merchants.first
+  end
+
   include SyncableInterfaceTest
 
   def setup

--- a/test/models/provider/stripe/subscription_event_processor_test.rb
+++ b/test/models/provider/stripe/subscription_event_processor_test.rb
@@ -54,4 +54,149 @@ class Provider::Stripe::SubscriptionEventProcessorTest < ActiveSupport::TestCase
     assert_equal "USD", family.subscription.currency
     assert family.subscription.current_period_ends_at > 20.days.from_now
   end
+
+  test "syncs matching subscription plan before app billing subscription" do
+    test_subscription_id = "sub-plan-test-id"
+    period_end = 1.month.from_now
+    subscription_plan = subscription_plans(:netflix_subscription)
+    subscription_plan.update!(
+      payment_method: "auto",
+      stripe_subscription_id: test_subscription_id
+    )
+
+    mock_event = JSON.parse({
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: test_subscription_id,
+          status: "active",
+          customer: "unrelated-customer-id",
+          cancel_at_period_end: true,
+          current_period_end: period_end.to_i,
+          items: {
+            data: [
+              {
+                current_period_end: period_end.to_i,
+                plan: {
+                  interval: "month",
+                  amount: 2299,
+                  currency: "usd"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }.to_json, object_class: OpenStruct)
+
+    Provider::Stripe::SubscriptionEventProcessor.new(mock_event).process
+
+    subscription_plan.reload
+    assert_equal "active", subscription_plan.stripe_status
+    assert subscription_plan.pending_cancellation?
+    assert_equal period_end.to_date, subscription_plan.expires_at
+  end
+
+  test "syncs Stripe pause collection into subscription plan lifecycle" do
+    test_subscription_id = "sub-paused-plan-id"
+    subscription_plan = subscription_plans(:netflix_subscription)
+    subscription_plan.update!(
+      payment_method: "auto",
+      stripe_subscription_id: test_subscription_id
+    )
+
+    mock_event = JSON.parse({
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: test_subscription_id,
+          status: "active",
+          customer: "unrelated-customer-id",
+          cancel_at_period_end: false,
+          pause_collection: { behavior: "void" },
+          items: {
+            data: [
+              {
+                id: "si_paused_plan",
+                current_period_end: 1.month.from_now.to_i,
+                plan: {
+                  interval: "month",
+                  amount: 2299,
+                  currency: "usd"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }.to_json, object_class: OpenStruct)
+
+    Provider::Stripe::SubscriptionEventProcessor.new(mock_event).process
+
+    subscription_plan.reload
+    assert_equal "paused", subscription_plan.status
+    assert_equal "void", subscription_plan.stripe_pause_collection_behavior
+    assert_equal "si_paused_plan", subscription_plan.stripe_subscription_item_id
+  end
+
+  test "ignores duplicate Stripe event delivery" do
+    subscription_plan = subscription_plans(:netflix_subscription)
+    subscription_plan.update!(payment_method: "auto", stripe_subscription_id: "sub_idempotent")
+    subscription = stripe_subscription_object(id: "sub_idempotent", status: "active")
+    event = stripe_event(id: "evt_duplicate", created: 1_750_000_000, subscription: subscription)
+
+    Provider::Stripe::SubscriptionEventProcessor.new(event).process
+    subscription.status = "canceled"
+    Provider::Stripe::SubscriptionEventProcessor.new(event).process
+
+    assert_equal "active", subscription_plan.reload.status
+    assert_equal 1, StripeEventReceipt.where(event_id: "evt_duplicate").count
+  end
+
+  test "ignores Stripe events older than the last applied event" do
+    subscription_plan = subscription_plans(:netflix_subscription)
+    subscription_plan.update!(payment_method: "auto", stripe_subscription_id: "sub_ordered")
+
+    newer_event = stripe_event(
+      id: "evt_newer",
+      created: 1_750_000_100,
+      subscription: stripe_subscription_object(id: "sub_ordered", status: "active")
+    )
+    stale_event = stripe_event(
+      id: "evt_stale",
+      created: 1_750_000_000,
+      subscription: stripe_subscription_object(id: "sub_ordered", status: "canceled")
+    )
+
+    Provider::Stripe::SubscriptionEventProcessor.new(newer_event).process
+    Provider::Stripe::SubscriptionEventProcessor.new(stale_event).process
+
+    subscription_plan.reload
+    assert_equal "active", subscription_plan.status
+    assert_equal "evt_newer", subscription_plan.stripe_last_event_id
+    assert_equal "ignored_stale", StripeEventReceipt.find_by!(event_id: "evt_stale").status
+  end
+
+  private
+    def stripe_event(id:, created:, subscription:)
+      OpenStruct.new(
+        id: id,
+        type: "customer.subscription.updated",
+        created: created,
+        data: OpenStruct.new(object: subscription)
+      )
+    end
+
+    def stripe_subscription_object(id:, status:)
+      OpenStruct.new(
+        id: id,
+        status: status,
+        customer: "cus_test",
+        cancel_at_period_end: false,
+        current_period_end: 1.month.from_now.to_i,
+        cancel_at: status == "canceled" ? Time.current.to_i : nil,
+        pause_collection: nil,
+        items: OpenStruct.new(data: [ OpenStruct.new(id: "si_test") ])
+      )
+    end
 end

--- a/test/models/service_merchant_test.rb
+++ b/test/models/service_merchant_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class ServiceMerchantTest < ActiveSupport::TestCase
+  test "available services include the catalog and current family services only" do
+    family = families(:dylan_family)
+    other_family = families(:empty)
+    catalog_service = ServiceMerchant.create!(
+      name: "Catalog Service",
+      subscription_category: "software",
+      popular: true
+    )
+    family_service = ServiceMerchant.create!(
+      name: "Family Service",
+      subscription_category: "software",
+      family: family
+    )
+    other_service = ServiceMerchant.create!(
+      name: "Other Family Service",
+      subscription_category: "software",
+      family: other_family
+    )
+    unowned_custom_service = ServiceMerchant.create!(
+      name: "Legacy Unowned Service",
+      subscription_category: "software"
+    )
+
+    available = ServiceMerchant.available_to(family)
+
+    assert_includes available, catalog_service
+    assert_includes available, family_service
+    assert_not_includes available, other_service
+    assert_not_includes available, unowned_custom_service
+  end
+
+  test "stores a flexible default schedule without requiring one" do
+    service = ServiceMerchant.new(
+      name: "Flexible Service",
+      subscription_category: "software",
+      default_interval_count: 14,
+      default_interval_unit: "day"
+    )
+
+    assert service.valid?
+    assert_equal "14_day", service.billing_frequency
+    assert_equal "Every 14 days", service.formatted_billing_frequency
+
+    service.default_interval_unit = ""
+    assert service.valid?
+    assert_nil service.billing_frequency
+    assert_equal "No default", service.formatted_billing_frequency
+  end
+end

--- a/test/models/subscription_plan/reminder_policy_test.rb
+++ b/test/models/subscription_plan/reminder_policy_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class SubscriptionPlan::ReminderPolicyTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  include ActionMailer::TestHelper
+
+  test "sends and deduplicates a two-day trial reminder" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(status: "trial", trial_ends_at: 2.days.from_now.to_date)
+    policy = SubscriptionPlan::ReminderPolicy.new
+
+    assert_emails 1 do
+      assert_equal({ renewal: 0, trial: 1 }, policy.deliver_upcoming!)
+    end
+
+    assert_emails 0 do
+      assert_equal({ renewal: 0, trial: 0 }, policy.deliver_upcoming!)
+    end
+  end
+
+  test "repairs legacy active records with a future trial date through reminder delivery" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(status: "active", trial_ends_at: 2.days.from_now.to_date)
+
+    assert_emails 1 do
+      assert_equal({ renewal: 0, trial: 1 }, SubscriptionPlan::ReminderPolicy.new.deliver_upcoming!)
+    end
+  end
+
+  test "sends trial expiration once" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(status: "trial", trial_ends_at: Date.current)
+    policy = SubscriptionPlan::ReminderPolicy.new
+
+    assert_emails 1 do
+      assert policy.deliver_trial_expired!(subscription)
+    end
+
+    assert_emails 0 do
+      assert_not policy.deliver_trial_expired!(subscription)
+    end
+  end
+
+  test "does not record delivery for a reserved example recipient" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(status: "trial", trial_ends_at: 2.days.from_now.to_date)
+    subscription.family.primary_user.update!(email: "uat@example.com")
+
+    assert_emails 0 do
+      assert_equal({ renewal: 0, trial: 0 }, SubscriptionPlan::ReminderPolicy.new.deliver_upcoming!)
+    end
+    assert_not subscription.audit_logs.where(event: "subscription.notification_sent").exists?
+  end
+end

--- a/test/models/subscription_plan/renewal_form_test.rb
+++ b/test/models/subscription_plan/renewal_form_test.rb
@@ -1,0 +1,174 @@
+require "test_helper"
+
+class SubscriptionPlan::RenewalFormTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:family_admin)
+    Current.session = @user.sessions.create!
+    @subscription_plan = subscription_plans(:netflix_subscription)
+    @account = accounts(:depository)
+    @category = categories(:food_and_drink)
+  end
+
+  test "valid with correct attributes" do
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: @account.id,
+      actual_amount: 22.99,
+      admin_fee: 1.50,
+      paid_at: Date.current,
+      currency: "USD",
+      category_id: @category.id
+    )
+    assert form.valid?
+  end
+
+  test "invalid with missing subscription_plan" do
+    form = SubscriptionPlan::RenewalForm.new(
+      account_id: @account.id,
+      actual_amount: 22.99,
+      paid_at: Date.current,
+      category_id: @category.id
+    )
+    assert_not form.valid?
+    assert_includes form.errors[:subscription_plan], "can't be blank"
+  end
+
+  test "invalid with missing account_id" do
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      actual_amount: 22.99,
+      paid_at: Date.current,
+      category_id: @category.id
+    )
+    assert_not form.valid?
+    assert_includes form.errors[:account_id], "can't be blank"
+  end
+
+  test "invalid with non-positive actual_amount" do
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: @account.id,
+      actual_amount: 0,
+      paid_at: Date.current,
+      category_id: @category.id
+    )
+    assert_not form.valid?
+    assert_includes form.errors[:actual_amount], "must be greater than 0"
+  end
+
+  test "invalid with negative admin_fee" do
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: @account.id,
+      actual_amount: 22.99,
+      admin_fee: -1,
+      paid_at: Date.current,
+      category_id: @category.id
+    )
+    assert_not form.valid?
+    assert_includes form.errors[:admin_fee], "must be greater than or equal to 0"
+  end
+
+  test "invalid with missing category_id when no default available" do
+    # Temporarily remove all family categories to force no default
+    Current.family.categories.destroy_all
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: @account.id,
+      actual_amount: 22.99,
+      paid_at: Date.current
+    )
+    assert_not form.valid?
+    assert_includes form.errors[:category_id], "can't be blank"
+  end
+
+  test "invalid with category from another family" do
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: @account.id,
+      actual_amount: 22.99,
+      paid_at: Date.current,
+      category_id: categories(:one).id
+    )
+
+    assert_not form.valid?
+    assert_includes form.errors[:category_id], "is invalid"
+  end
+
+  test "creates entry, transaction, renewal, advances billing, and updates default account when true" do
+    new_account = accounts(:credit_card)
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: new_account.id,
+      actual_amount: 22.99,
+      admin_fee: 1.50,
+      paid_at: Date.current,
+      currency: "USD",
+      category_id: @category.id,
+      update_default_account: true,
+      notes: "Payment recorded via test"
+    )
+
+    original_next_billing_at = @subscription_plan.next_billing_at
+    expected_next_billing_at = @subscription_plan.calculate_next_billing_date
+
+    assert_difference -> { @subscription_plan.subscription_renewals.count } => 1, -> { Entry.count } => 1 do
+      renewal = form.create
+      assert_not_nil renewal
+      assert_equal "paid", renewal.status
+      assert_equal new_account.id, renewal.account_id
+      assert_equal 22.99, renewal.actual_amount
+      assert_equal 1.50, renewal.admin_fee
+    end
+
+    @subscription_plan.reload
+    assert_equal new_account.id, @subscription_plan.account_id
+    assert_equal expected_next_billing_at, @subscription_plan.next_billing_at
+
+    # Verify positive amount is stored for expense (debit/outflow on asset account)
+    entry = @subscription_plan.subscription_renewals.paid.order(paid_at: :desc).first.entry
+    assert_equal 24.49, entry.amount # 22.99 actual_amount + 1.50 admin_fee
+    assert_equal @category.id, entry.entryable.category_id
+  end
+
+  test "does not update default account if update_default_account is false" do
+    original_account_id = @subscription_plan.account_id
+    new_account = accounts(:credit_card)
+
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: new_account.id,
+      actual_amount: 22.99,
+      paid_at: Date.current,
+      currency: "USD",
+      category_id: @category.id,
+      update_default_account: false
+    )
+
+    assert_not_nil form.create
+
+    @subscription_plan.reload
+    assert_equal original_account_id, @subscription_plan.account_id
+  end
+
+  test "creates renewal without Current family context" do
+    Current.reset
+    @subscription_plan.subscription_renewals.destroy_all
+
+    form = SubscriptionPlan::RenewalForm.new(
+      subscription_plan: @subscription_plan,
+      account_id: @account.id,
+      actual_amount: 22.99,
+      paid_at: Date.current,
+      currency: "USD"
+    )
+
+    assert_difference -> { @subscription_plan.subscription_renewals.count } => 1, -> { Entry.count } => 1 do
+      assert_not_nil form.create
+    end
+
+    renewal = @subscription_plan.subscription_renewals.last
+    assert_equal @account, renewal.account
+    assert_equal @subscription_plan.family, renewal.account.family
+  end
+end

--- a/test/models/subscription_plan_test.rb
+++ b/test/models/subscription_plan_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "ostruct"
 
 class SubscriptionPlanTest < ActiveSupport::TestCase
   setup do
@@ -69,6 +70,31 @@ class SubscriptionPlanTest < ActiveSupport::TestCase
     assert_equal "paused", @subscription.status
   end
 
+  test "pause uses Stripe pause collection for managed subscriptions" do
+    @subscription.update!(
+      payment_method: "auto",
+      stripe_subscription_id: "sub_test_123"
+    )
+
+    stripe_response = OpenStruct.new(
+      id: "sub_test_123",
+      status: "active",
+      cancel_at_period_end: false,
+      current_period_end: 1.month.from_now.to_i,
+      cancel_at: nil,
+      pause_collection: OpenStruct.new(behavior: "void"),
+      items: OpenStruct.new(data: [ OpenStruct.new(id: "si_test_123") ])
+    )
+
+    Stripe::Subscription.expects(:update)
+      .with("sub_test_123", pause_collection: { behavior: "void" })
+      .returns(stripe_response)
+
+    assert @subscription.pause!
+    assert_equal "paused", @subscription.reload.status
+    assert_equal "void", @subscription.stripe_pause_collection_behavior
+  end
+
   test "resume changes status to active" do
     @subscription.status = "paused"
     @subscription.save!
@@ -76,10 +102,254 @@ class SubscriptionPlanTest < ActiveSupport::TestCase
     assert_equal "active", @subscription.status
   end
 
+  test "resume clears Stripe pause collection for managed subscriptions" do
+    @subscription.update!(
+      status: "paused",
+      payment_method: "auto",
+      stripe_subscription_id: "sub_test_123",
+      metadata: {
+        "stripe" => {
+          "pause_collection" => { "behavior" => "void" },
+          "subscription_item_id" => "si_test_123"
+        }
+      }
+    )
+
+    stripe_response = OpenStruct.new(
+      id: "sub_test_123",
+      status: "active",
+      cancel_at_period_end: false,
+      current_period_end: 1.month.from_now.to_i,
+      cancel_at: nil,
+      pause_collection: nil,
+      items: OpenStruct.new(data: [ OpenStruct.new(id: "si_test_123") ])
+    )
+
+    Stripe::Subscription.expects(:update)
+      .with("sub_test_123", pause_collection: "")
+      .returns(stripe_response)
+
+    assert @subscription.resume!
+    assert_equal "active", @subscription.reload.status
+    assert_nil @subscription.stripe_pause_collection_behavior
+  end
+
   test "cancel changes status to cancelled" do
     @subscription.cancel!
     assert_equal "cancelled", @subscription.status
     assert_not @subscription.auto_renew
+  end
+
+  test "cancel at next renewal schedules Stripe period end cancellation" do
+    period_end = 1.month.from_now
+    @subscription.update!(
+      payment_method: "auto",
+      stripe_subscription_id: "sub_test_123",
+      stripe_customer_id: "cus_test_123"
+    )
+
+    stripe_response = OpenStruct.new(
+      status: "active",
+      cancel_at_period_end: true,
+      current_period_end: period_end.to_i,
+      cancel_at: nil
+    )
+
+    Stripe::Subscription.expects(:update)
+      .with("sub_test_123", cancel_at_period_end: true)
+      .returns(stripe_response)
+
+    @subscription.cancel!(at_next_renewal: true)
+
+    assert_equal "active", @subscription.reload.status
+    assert @subscription.pending_cancellation?
+    assert_not @subscription.auto_renew
+    assert_equal period_end.to_date, @subscription.expires_at
+  end
+
+  test "cancel immediately cancels Stripe subscription and keeps audit identifiers" do
+    cancel_time = Time.current
+    @subscription.update!(
+      payment_method: "auto",
+      stripe_subscription_id: "sub_test_123",
+      stripe_customer_id: "cus_test_123"
+    )
+
+    stripe_response = OpenStruct.new(
+      status: "canceled",
+      cancel_at_period_end: false,
+      current_period_end: nil,
+      cancel_at: cancel_time.to_i
+    )
+
+    Stripe::Subscription.expects(:cancel)
+      .with("sub_test_123")
+      .returns(stripe_response)
+
+    @subscription.cancel!
+
+    @subscription.reload
+    assert_equal "cancelled", @subscription.status
+    assert_not @subscription.cancel_at_period_end
+    assert_equal "sub_test_123", @subscription.stripe_subscription_id
+    assert_equal "cus_test_123", @subscription.stripe_customer_id
+  end
+
+  test "undo cancellation clears local period end cancellation" do
+    @subscription.update!(
+      cancel_at_period_end: true,
+      auto_renew: false,
+      expires_at: 1.month.from_now.to_date
+    )
+
+    assert @subscription.undo_cancellation!
+    assert_not @subscription.reload.cancel_at_period_end
+    assert @subscription.auto_renew
+    assert_nil @subscription.expires_at
+  end
+
+  test "undo cancellation clears Stripe period end cancellation" do
+    @subscription.update!(
+      payment_method: "auto",
+      stripe_subscription_id: "sub_test_123",
+      cancel_at_period_end: true,
+      auto_renew: false
+    )
+    stripe_response = OpenStruct.new(
+      status: "active",
+      cancel_at_period_end: false,
+      current_period_end: 1.month.from_now.to_i,
+      cancel_at: nil
+    )
+
+    Stripe::Subscription.expects(:update)
+      .with("sub_test_123", cancel_at_period_end: false)
+      .returns(stripe_response)
+
+    assert @subscription.undo_cancellation!
+    assert_not @subscription.reload.cancel_at_period_end
+    assert @subscription.auto_renew
+  end
+
+  test "failed Stripe cancellation undo preserves pending cancellation" do
+    @subscription.update!(
+      payment_method: "auto",
+      stripe_subscription_id: "sub_test_123",
+      cancel_at_period_end: true,
+      auto_renew: false
+    )
+    Stripe::Subscription.expects(:update)
+      .with("sub_test_123", cancel_at_period_end: false)
+      .raises(Stripe::InvalidRequestError.new("cannot update", "subscription"))
+
+    assert_not @subscription.undo_cancellation!
+    assert @subscription.reload.cancel_at_period_end
+    assert_not @subscription.auto_renew
+  end
+
+  test "failed Stripe cancellation does not change local lifecycle" do
+    @subscription.update!(
+      payment_method: "auto",
+      stripe_subscription_id: "sub_test_123"
+    )
+
+    Stripe::Subscription.expects(:cancel)
+      .with("sub_test_123")
+      .raises(Stripe::InvalidRequestError.new("cannot cancel", "subscription"))
+
+    assert_not @subscription.cancel!
+    assert_equal "active", @subscription.reload.status
+    assert @subscription.auto_renew
+    assert_includes @subscription.errors[:base], "Stripe cancellation failed: cannot cancel"
+  end
+
+  test "update Stripe subscription uses subscription item id" do
+    @subscription.update!(
+      payment_method: "auto",
+      stripe_subscription_id: "sub_test_123"
+    )
+
+    current_subscription = OpenStruct.new(
+      items: OpenStruct.new(data: [ OpenStruct.new(id: "si_test_123", quantity: 2) ])
+    )
+    updated_subscription = OpenStruct.new(
+      id: "sub_test_123",
+      status: "active",
+      cancel_at_period_end: false,
+      current_period_end: 1.month.from_now.to_i,
+      cancel_at: nil,
+      pause_collection: nil,
+      items: OpenStruct.new(data: [ OpenStruct.new(id: "si_test_123", quantity: 2) ])
+    )
+
+    Stripe::Subscription.expects(:retrieve)
+      .with("sub_test_123")
+      .returns(current_subscription)
+    Stripe::Subscription.expects(:update)
+      .with(
+        "sub_test_123",
+        items: [ { id: "si_test_123", price: "price_new", quantity: 2 } ],
+        proration_behavior: "create_prorations"
+      )
+      .returns(updated_subscription)
+
+    assert @subscription.update_stripe_subscription("price_new")
+    assert_equal "si_test_123", @subscription.reload.stripe_subscription_item_id
+  end
+
+  test "sync_from_stripe_subscription stores pending cancellation state" do
+    period_end = 1.month.from_now
+    stripe_subscription = OpenStruct.new(
+      status: "active",
+      cancel_at_period_end: true,
+      current_period_end: period_end.to_i,
+      cancel_at: nil
+    )
+
+    @subscription.sync_from_stripe_subscription!(stripe_subscription)
+
+    @subscription.reload
+    assert_equal "active", @subscription.status
+    assert_equal "active", @subscription.stripe_status
+    assert @subscription.pending_cancellation?
+    assert_not @subscription.auto_renew
+    assert_equal period_end.to_date, @subscription.expires_at
+  end
+
+  test "sync_from_stripe_subscription maps pause collection to paused lifecycle" do
+    stripe_subscription = OpenStruct.new(
+      status: "active",
+      cancel_at_period_end: false,
+      current_period_end: 1.month.from_now.to_i,
+      cancel_at: nil,
+      pause_collection: OpenStruct.new(behavior: "void"),
+      items: OpenStruct.new(data: [ OpenStruct.new(id: "si_test_123") ])
+    )
+
+    @subscription.sync_from_stripe_subscription!(stripe_subscription)
+
+    @subscription.reload
+    assert_equal "paused", @subscription.status
+    assert_equal "void", @subscription.stripe_pause_collection_behavior
+    assert_equal "si_test_123", @subscription.stripe_subscription_item_id
+  end
+
+  test "sync_from_stripe_subscription stores canceled state" do
+    cancel_time = Time.current
+    stripe_subscription = OpenStruct.new(
+      status: "canceled",
+      cancel_at_period_end: false,
+      current_period_end: nil,
+      cancel_at: cancel_time.to_i
+    )
+
+    @subscription.sync_from_stripe_subscription!(stripe_subscription)
+
+    @subscription.reload
+    assert_equal "cancelled", @subscription.status
+    assert_equal "canceled", @subscription.stripe_status
+    assert_not @subscription.auto_renew
+    assert_equal cancel_time.to_date, @subscription.cancelled_at
   end
 
   test "scope active returns only active subscriptions" do
@@ -178,5 +448,93 @@ class SubscriptionPlanTest < ActiveSupport::TestCase
     # Second call should fail (billing already advanced)
     result_second = @subscription.record_manual_payment!(paid_at: Date.current)
     assert_equal false, result_second
+  end
+
+  test "record_payment_entry creates renewal and advances billing" do
+    @subscription.subscription_renewals.destroy_all
+    @subscription.update!(next_billing_at: Date.current)
+
+    entry = @subscription.account.entries.create!(
+      name: "Netflix payment",
+      date: Date.current,
+      amount: @subscription.amount,
+      currency: @subscription.currency,
+      entryable: Transaction.new(
+        kind: "standard",
+        category: categories(:food_and_drink),
+        merchant: merchants(:netflix)
+      )
+    )
+
+    assert_difference -> { @subscription.subscription_renewals.count } => 1 do
+      assert @subscription.record_payment_entry!(entry)
+    end
+
+    renewal = @subscription.subscription_renewals.last
+    assert_equal entry, renewal.entry
+    assert_equal "paid", renewal.status
+    assert_equal Date.current.next_month, @subscription.reload.next_billing_at
+  end
+
+  test "record_payment_entry does not create duplicate renewal for same entry" do
+    @subscription.subscription_renewals.destroy_all
+    @subscription.update!(next_billing_at: Date.current)
+
+    entry = @subscription.account.entries.create!(
+      name: "Netflix payment",
+      date: Date.current,
+      amount: @subscription.amount,
+      currency: @subscription.currency,
+      entryable: Transaction.new(
+        kind: "standard",
+        category: categories(:food_and_drink),
+        merchant: merchants(:netflix)
+      )
+    )
+
+    assert @subscription.record_payment_entry!(entry)
+
+    assert_no_difference -> { @subscription.subscription_renewals.count } do
+      assert_not @subscription.record_payment_entry!(entry)
+    end
+  end
+
+  test "one-time payment completes the subscription instead of advancing" do
+    @subscription.update!(
+      next_billing_at: Date.current,
+      billing_cycle: "one_time",
+      metadata: { "schedule" => { "count" => 1, "unit" => "once" } }
+    )
+
+    @subscription.mark_as_renewed!(Date.current)
+
+    assert @subscription.reload.expired?
+    assert_not @subscription.auto_renew
+    assert_equal Date.current, @subscription.expires_at
+  end
+
+  test "future trial date normalizes a new active subscription to trial" do
+    subscription = @subscription.dup
+    subscription.name = "Trial normalization"
+    subscription.trial_ends_at = 2.days.from_now.to_date
+    subscription.status = "active"
+
+    assert subscription.valid?
+    assert_equal "trial", subscription.status
+  end
+
+  test "next billing date cannot precede the start date" do
+    @subscription.started_at = Date.current
+    @subscription.next_billing_at = Date.yesterday
+
+    assert_not @subscription.valid?
+    assert_includes @subscription.errors[:next_billing_at], "cannot be before the start date"
+  end
+
+  test "one-time subscription does not present a monthly equivalent" do
+    @subscription.metadata = { "schedule" => { "count" => 1, "unit" => "once" } }
+    @subscription.billing_cycle = "one_time"
+
+    assert_equal "Not recurring", @subscription.formatted_monthly_amount
   end
 end


### PR DESCRIPTION
## Summary
- add flexible recurring schedules, renewal records, billing windows, manual payment reconciliation, and lifecycle history
- implement pause, resume, immediate/period-end cancellation, Stripe webhook ordering/idempotency, and renewal/trial reminders
- scope custom services per family and expose subscribed services in transaction merchant selection
- refresh Subscription Manager UI and add focused controller/model/job/mailer coverage

## Data safety
- migrates legacy shared custom services into family-scoped copies when subscriptions reference them
- enforces a partial unique index for family-owned ServiceMerchant names
- uses migration-local SQL for renewal entry normalization
- validates migration down/up behavior on disposable PostgreSQL 18

## Verification
- `bin/rails test`: 1822 runs, 8925 assertions, 0 failures, 0 errors, 19 skips
- `bin/rubocop`: 1244 files, no offenses
- `npm run lint`: 95 files, no issues
- `bin/brakeman --no-pager`: 0 security warnings
