### PR TITLE
Unify recurring intelligence and reconciliation

### DIFF
--- a/app/controllers/recurring_controller.rb
+++ b/app/controllers/recurring_controller.rb
@@ -1,0 +1,31 @@
+class RecurringController < ApplicationController
+  def index
+    subscriptions = Current.family.subscription_plans.unarchived
+    recurring_transactions = Current.family.recurring_transactions
+
+    @active_subscriptions = subscriptions.active
+    @monthly_commitment = @active_subscriptions.sum(&:monthly_equivalent_amount)
+    @detected_count = recurring_transactions.visible.where(destination_account_id: nil).count
+    @transfer_count = recurring_transactions.visible.where.not(destination_account_id: nil).count
+    @ignored_count = recurring_transactions.ignored.count
+    @upcoming_subscriptions = @active_subscriptions
+      .where.not(next_billing_at: nil)
+      .order(:next_billing_at)
+      .limit(5)
+    @upcoming_patterns = recurring_transactions
+      .visible
+      .active
+      .where.not(next_expected_date: nil)
+      .order(:next_expected_date)
+      .limit(5)
+    @forecast = Recurring::Forecast.new(Current.family)
+    @forecast_items = @forecast.projected_items.first(12)
+    auditable_ids = subscriptions.pluck(:id) + recurring_transactions.pluck(:id)
+    @recent_events = AuditLog
+      .recurring_events
+      .where(auditable_type: %w[SubscriptionPlan RecurringTransaction], auditable_id: auditable_ids)
+      .preload(:auditable)
+      .reverse_chronological
+      .limit(10)
+  end
+end

--- a/app/controllers/recurring_transactions_controller.rb
+++ b/app/controllers/recurring_transactions_controller.rb
@@ -1,10 +1,20 @@
 class RecurringTransactionsController < ApplicationController
-  layout "settings"
-
   def index
-    @recurring_transactions = Current.family.recurring_transactions
-                                    .includes(:merchant)
-                                    .order(status: :asc, next_expected_date: :asc)
+    @recurring_view = params[:kind].presence_in(%w[transfers ignored]) || "detected"
+    recurring_transactions = Current.family.recurring_transactions.includes(:merchant, :account, :destination_account)
+
+    recurring_scope =
+      case @recurring_view
+      when "transfers"
+        recurring_transactions.visible.where.not(destination_account_id: nil)
+      when "ignored"
+        recurring_transactions.where(status: "ignored")
+      else
+        recurring_transactions.visible.where(destination_account_id: nil)
+      end.order(status: :asc, next_expected_date: :asc)
+    @pagy, @recurring_transactions = pagy(:offset, recurring_scope, limit: 25)
+    @assessments = @recurring_transactions.index_with(&:recurring_assessment)
+    @transfer_destinations = Current.family.accounts.order(:name) if @recurring_view == "detected"
   end
 
   def identify
@@ -30,7 +40,7 @@ class RecurringTransactionsController < ApplicationController
   end
 
   def toggle_status
-    @recurring_transaction = Current.family.recurring_transactions.find(params[:id])
+    @recurring_transaction = Current.family.recurring_transactions.visible.find(params[:id])
 
     if @recurring_transaction.active?
       @recurring_transaction.mark_inactive!
@@ -43,16 +53,56 @@ class RecurringTransactionsController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:notice] = message
-        redirect_to recurring_transactions_path
+        redirect_to recurring_transactions_path(kind: params[:kind])
       end
     end
   end
 
+  def create_subscription
+    @recurring_transaction = Current.family.recurring_transactions.visible.find(params[:id])
+    subscription_plan = @recurring_transaction.create_subscription_plan!
+
+    flash[:notice] = "Subscription plan created from recurring transaction."
+    redirect_to subscription_plan_path(subscription_plan)
+  rescue ActiveRecord::RecordInvalid, ArgumentError => e
+    Rails.logger.warn("Failed to create subscription from recurring transaction #{params[:id]}: #{e.message}")
+    flash[:alert] = e.message
+    redirect_to recurring_transactions_path
+  end
+
   def destroy
-    @recurring_transaction = Current.family.recurring_transactions.find(params[:id])
-    @recurring_transaction.destroy!
+    @recurring_transaction = Current.family.recurring_transactions.visible.find(params[:id])
+    @recurring_transaction.ignore!
 
     flash[:notice] = t("recurring_transactions.deleted")
+    redirect_to recurring_transactions_path(kind: params[:kind])
+  end
+
+  def restore
+    @recurring_transaction = Current.family.recurring_transactions.ignored.find(params[:id])
+    @recurring_transaction.restore!
+
+    flash[:notice] = "Recurring transaction restored and eligible for future detection."
+    redirect_to recurring_transactions_path(kind: "ignored")
+  end
+
+  def confirm
+    recurring_transaction = Current.family.recurring_transactions.visible.find(params[:id])
+    recurring_transaction.confirm_as_recurring!
+
+    flash[:notice] = "Recurring pattern confirmed."
+    redirect_to recurring_transactions_path
+  end
+
+  def mark_transfer
+    recurring_transaction = Current.family.recurring_transactions.visible.find(params[:id])
+    destination_account = Current.family.accounts.find(params.require(:destination_account_id))
+    recurring_transaction.mark_as_transfer!(destination_account)
+
+    flash[:notice] = "Recurring pattern classified as a transfer."
+    redirect_to recurring_transactions_path(kind: "transfers")
+  rescue ArgumentError => error
+    flash[:alert] = error.message
     redirect_to recurring_transactions_path
   end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -388,6 +388,7 @@ class TransactionsController < ApplicationController
 
     # Check if a recurring transaction already exists for this pattern
     existing = Current.family.recurring_transactions.find_by(
+      account_id: transaction.entry.account_id,
       merchant_id: transaction.merchant_id,
       name: transaction.merchant_id.present? ? nil : transaction.entry.name,
       currency: transaction.entry.currency,

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -1,7 +1,7 @@
 class TransfersController < ApplicationController
   include StreamExtensions
 
-  before_action :set_transfer, only: %i[show destroy update]
+  before_action :set_transfer, only: %i[show destroy update mark_as_recurring]
 
   def new
     @transfer = Transfer.new
@@ -9,6 +9,12 @@ class TransfersController < ApplicationController
 
   def show
     @categories = Current.family.categories.expenses
+    @recurring_transfer_exists = Current.family.recurring_transactions.exists?(
+      account_id: @transfer.from_account&.id,
+      destination_account_id: @transfer.to_account&.id,
+      amount: @transfer.outflow_transaction&.entry&.amount,
+      currency: @transfer.outflow_transaction&.entry&.currency
+    )
   end
 
   def create
@@ -68,6 +74,16 @@ class TransfersController < ApplicationController
   def destroy
     @transfer.destroy!
     redirect_back_or_to transactions_url, notice: t(".success")
+  end
+
+  def mark_as_recurring
+    recurring = RecurringTransaction.create_from_transfer(@transfer)
+    redirect_to recurring_transactions_path, notice: "Transfer marked as recurring."
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+    Rails.logger.warn("Recurring transfer creation rejected for transfer #{@transfer&.id}: #{e.message}")
+    redirect_back_or_to transactions_path, alert: "This recurring transfer already exists or is invalid."
+  rescue ArgumentError => e
+    redirect_back_or_to transactions_path, alert: e.message
   end
 
   private

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -13,7 +13,6 @@ module SettingsHelper
     { name: "Tags", path: :tags_path },
     { name: "Rules", path: :rules_path },
     { name: "Merchants", path: :family_merchants_path },
-    { name: "Recurring", path: :recurring_transactions_path },
     # Advanced section
     { name: "AI Prompts", path: :settings_ai_prompts_path, condition: :admin_user? },
     { name: "LLM Usage", path: :settings_llm_usage_path, condition: :admin_user? },

--- a/app/jobs/identify_recurring_transactions_job.rb
+++ b/app/jobs/identify_recurring_transactions_job.rb
@@ -1,0 +1,55 @@
+require "digest"
+
+class IdentifyRecurringTransactionsJob < ApplicationJob
+  queue_as :default
+
+  DEBOUNCE_DELAY = 30.seconds
+  CACHE_TTL = DEBOUNCE_DELAY + 1.minute
+  ADVISORY_LOCK_NAMESPACE = 1_947_203_321
+
+  def self.schedule_for(family)
+    scheduled_at = Time.current.to_f
+    Rails.cache.write(cache_key(family.id), scheduled_at, expires_in: CACHE_TTL)
+    set(wait: DEBOUNCE_DELAY).perform_later(family.id, scheduled_at)
+  end
+
+  def self.cache_key(family_id)
+    "recurring_transaction_identify:#{family_id}"
+  end
+
+  def perform(family_id, scheduled_at)
+    family = Family.find_by(id: family_id)
+    return unless family
+    return if superseded?(family_id, scheduled_at)
+    return if Sync.any_incomplete_for?(family)
+
+    with_advisory_lock(family_id) do
+      RecurringTransaction.identify_patterns_for(family)
+    end
+  end
+
+  private
+    def superseded?(family_id, scheduled_at)
+      latest_scheduled_at = Rails.cache.read(self.class.cache_key(family_id))
+      latest_scheduled_at.present? && latest_scheduled_at.to_f > scheduled_at.to_f
+    end
+
+    def with_advisory_lock(family_id)
+      connection = ActiveRecord::Base.connection
+      lock_id = Digest::SHA256.hexdigest(family_id.to_s).to_i(16) % (2**31)
+      lock_sql = ActiveRecord::Base.sanitize_sql_array(
+        [ "SELECT pg_try_advisory_lock(?, ?)", ADVISORY_LOCK_NAMESPACE, lock_id ]
+      )
+      acquired = connection.select_value(lock_sql)
+      return unless ActiveModel::Type::Boolean.new.cast(acquired)
+
+      yield
+    ensure
+      if acquired
+        unlock_sql = ActiveRecord::Base.sanitize_sql_array(
+          [ "SELECT pg_advisory_unlock(?, ?)", ADVISORY_LOCK_NAMESPACE, lock_id ]
+        )
+        connection.select_value(unlock_sql)
+      end
+    end
+end

--- a/app/jobs/reconcile_transaction_job.rb
+++ b/app/jobs/reconcile_transaction_job.rb
@@ -1,0 +1,18 @@
+class ReconcileTransactionJob < ApplicationJob
+  queue_as :medium_priority
+
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(entry_id)
+    entry = Entry.includes(:account, :entryable).find(entry_id)
+    return unless entry.entryable_type == "Transaction"
+    return if SubscriptionRenewal.where(entry_id: entry.id).exists?
+
+    results = Recurring::Reconciler.new(
+      entry.account.family,
+      as_of: entry.date,
+      entry: entry
+    ).reconcile!
+    Recurring::Notifier.new(entry.account.family, as_of: entry.date).deliver! if results.any?
+  end
+end

--- a/app/jobs/recurring_intelligence_job.rb
+++ b/app/jobs/recurring_intelligence_job.rb
@@ -1,0 +1,20 @@
+class RecurringIntelligenceJob < ApplicationJob
+  queue_as :scheduled
+
+  def perform(date = Date.current)
+    Family.find_each do |family|
+      Recurring::Reconciler.new(family, as_of: date).reconcile!
+      Recurring::Notifier.new(family, as_of: date).deliver!
+    rescue => error
+      Rails.logger.error(
+        {
+          at: "RecurringIntelligenceJob",
+          family_id: family.id,
+          date: date,
+          error: error.message
+        }.to_json
+      )
+      Sentry.capture_exception(error, tags: { job: self.class.name, family_id: family.id }) if defined?(Sentry)
+    end
+  end
+end

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -68,6 +68,20 @@ class SubscriptionMailer < ApplicationMailer
     mail(to: recipient, subject: "Your #{subscription.name} trial has expired")
   end
 
+  def recurring_anomaly(family, commitment, event)
+    @family = family
+    @commitment = commitment
+    @event_data = event.changeset
+
+    recipient = safe_recipient_email(family)
+    return unless recipient.present?
+
+    mail(
+      to: recipient,
+      subject: "Recurring payment needs attention: #{commitment.name}"
+    )
+  end
+
   # Subscription cancelled confirmation
   def subscription_cancelled(subscription)
     @subscription = subscription

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -17,6 +17,8 @@ class Account < ApplicationRecord
   has_many :loan_installments, dependent: :destroy
   has_many :subscription_plans, dependent: :destroy
   has_many :subscription_renewals, dependent: :nullify
+  has_many :recurring_transactions, dependent: :destroy
+  has_many :recurring_transaction_suppressions, dependent: :destroy
 
   monetize :balance, :cash_balance
 

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -3,4 +3,5 @@ class AuditLog < ApplicationRecord
   belongs_to :user, optional: true
 
   scope :reverse_chronological, -> { order(created_at: :desc) }
+  scope :recurring_events, -> { where("event LIKE ?", "recurring.%") }
 end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -181,6 +181,18 @@ class Budget < ApplicationRecord
     (budgeted_spending || 0) - actual_spending
   end
 
+  def projected_recurring_spending
+    Recurring::Forecast.new(
+      family,
+      start_date: [ start_date, Date.current ].max,
+      end_date: end_date
+    ).projected_outflow
+  end
+
+  def projected_available_to_spend
+    available_to_spend - projected_recurring_spending
+  end
+
   def percent_of_budget_spent
     return 0 unless budgeted_spending > 0
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -41,6 +41,7 @@ class Entry < ApplicationRecord
   validate :split_child_date_matches_parent
 
   before_destroy :prevent_individual_child_deletion, if: :split_child?
+  after_commit :enqueue_recurring_reconciliation, on: %i[create update]
 
   scope :visible, -> {
     joins(:account).where(accounts: { status: [ "draft", "active" ] })
@@ -372,6 +373,13 @@ class Entry < ApplicationRecord
 
     ALLOWED_RECEIPT_TYPES = %w[image/jpeg image/png image/webp application/pdf].freeze
     MAX_RECEIPT_SIZE = 10.megabytes
+
+    def enqueue_recurring_reconciliation
+      return unless entryable_type == "Transaction"
+      return unless previous_changes.keys.intersect?(%w[id date amount currency account_id entryable_id])
+
+      ReconcileTransactionJob.perform_later(id)
+    end
 
     def receipt_content_type_valid
       unless receipt.content_type.in?(ALLOWED_RECEIPT_TYPES)

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -36,6 +36,7 @@ class Family < ApplicationRecord
 
   has_many :llm_usages, dependent: :destroy
   has_many :recurring_transactions, dependent: :destroy
+  has_many :recurring_transaction_suppressions, dependent: :destroy
   has_many :subscription_plans, dependent: :destroy
 
   def primary_user

--- a/app/models/family/sync_complete_event.rb
+++ b/app/models/family/sync_complete_event.rb
@@ -43,11 +43,12 @@ class Family::SyncCompleteEvent
       )
     end
 
-    # Identify recurring transaction patterns after sync
+    # Debounce identification so overlapping provider syncs cannot analyze a
+    # partial transaction set or run the same family concurrently.
     begin
-      RecurringTransaction.identify_patterns_for(family)
+      RecurringTransaction.schedule_identification_for(family)
     rescue => e
-      Rails.logger.error("Family::SyncCompleteEvent recurring transaction identification failed: #{e.message}\n#{e.backtrace&.join("\n")}")
+      Rails.logger.error("Family::SyncCompleteEvent recurring transaction scheduling failed: #{e.message}\n#{e.backtrace&.join("\n")}")
     end
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -3,6 +3,7 @@ class Merchant < ApplicationRecord
 
   has_many :transactions, dependent: :nullify
   has_many :recurring_transactions, dependent: :destroy
+  has_many :recurring_transaction_suppressions, dependent: :nullify
   has_many :subscription_plans, dependent: :nullify
 
   validates :name, presence: true

--- a/app/models/recurring/assessment.rb
+++ b/app/models/recurring/assessment.rb
@@ -1,0 +1,87 @@
+module Recurring
+  class Assessment
+    attr_reader :recurring_transaction
+
+    def initialize(recurring_transaction)
+      @recurring_transaction = recurring_transaction
+    end
+
+    def score
+      @score ||= [
+        occurrence_score,
+        identity_score,
+        account_score,
+        schedule_score,
+        amount_score,
+        recency_score
+      ].sum.clamp(0, 100)
+    end
+
+    def label
+      return "High" if score >= 80
+      return "Medium" if score >= 55
+
+      "Low"
+    end
+
+    def evidence
+      {
+        occurrence_count: recurring_transaction.occurrence_count,
+        matched_transactions: matching_entries.size,
+        merchant_or_name: recurring_transaction.merchant&.name || recurring_transaction.name,
+        account: recurring_transaction.account&.name,
+        amount_range: amount_range,
+        last_occurrence_date: recurring_transaction.last_occurrence_date,
+        next_expected_date: recurring_transaction.next_expected_date
+      }
+    end
+
+    def matching_entries
+      @matching_entries ||= recurring_transaction.matching_transactions.limit(6).to_a
+    end
+
+    def reviewed?
+      recurring_transaction.audit_logs.where(event: "recurring.confirmed").exists?
+    end
+
+    private
+      def occurrence_score
+        [ recurring_transaction.occurrence_count * 10, 30 ].min
+      end
+
+      def identity_score
+        recurring_transaction.merchant_id.present? ? 20 : 12
+      end
+
+      def account_score
+        recurring_transaction.account_id.present? ? 15 : 0
+      end
+
+      def schedule_score
+        matching_entries.size >= 3 ? 15 : matching_entries.size * 4
+      end
+
+      def amount_score
+        return 10 unless recurring_transaction.has_amount_variance?
+
+        average = recurring_transaction.expected_amount_avg.to_d.abs
+        return 0 if average.zero?
+
+        spread = recurring_transaction.expected_amount_max.to_d - recurring_transaction.expected_amount_min.to_d
+        (15 - ((spread.abs / average) * 100).round).clamp(0, 15)
+      end
+
+      def recency_score
+        return 0 if recurring_transaction.last_occurrence_date.blank?
+        return 5 if recurring_transaction.last_occurrence_date < 3.months.ago.to_date
+
+        10
+      end
+
+      def amount_range
+        minimum = recurring_transaction.expected_amount_min || recurring_transaction.amount
+        maximum = recurring_transaction.expected_amount_max || recurring_transaction.amount
+        [ minimum, maximum ]
+      end
+  end
+end

--- a/app/models/recurring/forecast.rb
+++ b/app/models/recurring/forecast.rb
@@ -1,0 +1,93 @@
+module Recurring
+  class Forecast
+    Item = Data.define(:commitment, :date, :amount, :currency, :kind, :actualized)
+
+    attr_reader :family, :start_date, :end_date
+
+    def initialize(family, start_date: Date.current, end_date: 30.days.from_now.to_date)
+      @family = family
+      @start_date = start_date.to_date
+      @end_date = end_date.to_date
+    end
+
+    def items
+      @items ||= (subscription_items + recurring_items).sort_by(&:date)
+    end
+
+    def projected_items
+      items.reject(&:actualized)
+    end
+
+    def projected_outflow
+      projected_items
+        .select { |item| item.currency == family.currency }
+        .sum { |item| item.amount.to_d.abs }
+    end
+
+    private
+      def subscription_items
+        family.subscription_plans.unarchived
+          .where(status: %w[active trial])
+          .where.not(next_billing_at: nil)
+          .flat_map do |subscription|
+            occurrence_dates(subscription.next_billing_at, subscription.schedule).map do |date|
+              build_item(subscription, date, subscription.amount, "subscription")
+            end
+          end
+      end
+
+      def recurring_items
+        family.recurring_transactions.visible.active
+          .where.not(next_expected_date: nil)
+          .flat_map do |recurring_transaction|
+            occurrence_dates(recurring_transaction.next_expected_date, recurring_transaction.schedule).map do |date|
+              build_item(
+                recurring_transaction,
+                date,
+                recurring_transaction.expected_amount_avg || recurring_transaction.amount,
+                recurring_transaction.transfer? ? "transfer" : "recurring"
+              )
+            end
+          end
+      end
+
+      def occurrence_dates(first_date, schedule)
+        date = first_date.to_date
+        dates = []
+
+        while date <= end_date
+          dates << date if date >= start_date
+          date = schedule.advance(date)
+          break if date.blank?
+        end
+
+        dates
+      end
+
+      def build_item(commitment, date, amount, kind)
+        Item.new(
+          commitment: commitment,
+          date: date,
+          amount: amount,
+          currency: commitment.currency,
+          kind: kind,
+          actualized: actualized?(commitment, date)
+        )
+      end
+
+      def actualized?(commitment, date)
+        family.transactions
+          .where("transactions.extra -> 'recurring_matches' IS NOT NULL")
+          .where(
+            "transactions.extra -> 'recurring_matches' @> ?::jsonb",
+            {
+              "#{commitment.class.name}:#{commitment.id}:#{date}" => {
+                "commitment_id" => commitment.id,
+                "expected_date" => date.to_s
+              }
+            }.to_json
+          )
+          .exists?
+      end
+  end
+end

--- a/app/models/recurring/notifier.rb
+++ b/app/models/recurring/notifier.rb
@@ -1,0 +1,53 @@
+module Recurring
+  class Notifier
+    ALERT_STATUSES = %w[missed duplicate amount_changed unexpected_renewal].freeze
+
+    attr_reader :family, :as_of
+
+    def initialize(family, as_of: Date.current)
+      @family = family
+      @as_of = as_of.to_date
+    end
+
+    def deliver!
+      alert_events.find_each.count do |event|
+        deliver_event(event)
+      end
+    end
+
+    private
+      def alert_events
+        AuditLog
+          .where(auditable_type: %w[SubscriptionPlan RecurringTransaction])
+          .where(event: ALERT_STATUSES.map { |status| "recurring.#{status}" })
+          .where(created_at: 7.days.ago.beginning_of_day..Time.current)
+          .where.not(id: delivered_event_ids)
+      end
+
+      def delivered_event_ids
+        AuditLog.where(event: "recurring.notification_sent")
+          .where("changeset -> 'metadata' ->> 'family_id' = ?", family.id.to_s)
+          .pluck(Arel.sql("changeset -> 'metadata' ->> 'source_event_id'"))
+      end
+
+      def deliver_event(event)
+        commitment = event.auditable
+        return false unless commitment&.family_id == family.id
+
+        SubscriptionMailer.recurring_anomaly(family, commitment, event).deliver_later
+        EventRecorder.record!(
+          record: commitment,
+          event: "recurring.notification_sent",
+          key: "notification:#{event.id}",
+          title: "Notification sent",
+          detail: event.changeset["title"],
+          metadata: {
+            family_id: family.id,
+            source_event_id: event.id,
+            delivered_on: as_of
+          }
+        )
+        true
+      end
+  end
+end

--- a/app/models/recurring/reconciler.rb
+++ b/app/models/recurring/reconciler.rb
@@ -1,0 +1,289 @@
+module Recurring
+  class Reconciler
+    Result = Data.define(
+      :commitment,
+      :status,
+      :expected_date,
+      :expected_amount,
+      :entries,
+      :confidence,
+      :detail
+    )
+
+    DATE_TOLERANCE = 3.days
+    MISSING_GRACE = 3.days
+    AMOUNT_TOLERANCE = 0.05
+    RECONCILIATION_LOOKBACK = 45.days
+
+    attr_reader :family, :as_of, :entry
+
+    def initialize(family, as_of: Date.current, entry: nil)
+      @family = family
+      @as_of = as_of.to_date
+      @entry = entry
+    end
+
+    def reconcile!
+      ApplicationRecord.transaction do
+        results = subscription_results + recurring_results
+        results.each { |result| persist!(result) }
+
+        ActiveSupport::Notifications.instrument(
+          "sure.recurring.reconciled",
+          family_id: family.id,
+          as_of: as_of,
+          counts: results.tally { |result| result.status }
+        )
+
+        results
+      end
+    end
+
+    private
+      def subscription_results
+        expected_results = subscription_scope
+          .where(status: %w[active trial])
+          .where.not(next_billing_at: nil)
+          .flat_map do |subscription|
+            subscription_occurrences(subscription).map do |occurrence|
+              build_result(subscription, occurrence[:date], occurrence[:amount])
+            end
+          end
+
+        expected_results + unexpected_subscription_results
+      end
+
+      def subscription_occurrences(subscription)
+        occurrences = subscription.subscription_renewals
+          .where(billing_period_start: (as_of - RECONCILIATION_LOOKBACK)..as_of)
+          .pluck(:billing_period_start, :template_amount)
+          .map { |date, amount| { date: date, amount: amount } }
+
+        if subscription.next_billing_at <= as_of
+          occurrences << { date: subscription.next_billing_at, amount: subscription.amount }
+        end
+
+        occurrences.uniq { |occurrence| occurrence[:date] }
+      end
+
+      def unexpected_subscription_results
+        subscription_scope
+          .where(status: %w[paused cancelled expired])
+          .filter_map do |subscription|
+            entries = candidates_for(subscription, as_of)
+            next if entries.empty?
+
+            Result.new(
+              commitment: subscription,
+              status: "unexpected_renewal",
+              expected_date: entries.first.date,
+              expected_amount: subscription.amount,
+              entries: entries,
+              confidence: confidence_for(entries, subscription.amount),
+              detail: "A charge was found while the subscription was #{subscription.status}."
+            )
+          end
+      end
+
+      def recurring_results
+        recurring_scope.visible.active.filter_map do |recurring_transaction|
+          expected_date = recurring_transaction.next_expected_date
+          next if expected_date.blank? || expected_date > as_of
+
+          build_result(recurring_transaction, expected_date, recurring_transaction.amount)
+        end
+      end
+
+      def build_result(commitment, expected_date, expected_amount)
+        entries = candidates_for(commitment, expected_date)
+        status = classify(entries, expected_date, expected_amount)
+        confidence = confidence_for(entries, expected_amount)
+
+        Result.new(
+          commitment: commitment,
+          status: status,
+          expected_date: expected_date,
+          expected_amount: expected_amount,
+          entries: entries,
+          confidence: confidence,
+          detail: detail_for(status, entries, expected_amount)
+        )
+      end
+
+      def candidates_for(commitment, expected_date)
+        scope = entry.present? ? family.entries.where(id: entry.id) : family.entries
+        scope = scope
+          .preload(:entryable)
+          .where(entryable_type: "Transaction", currency: commitment.currency)
+          .where(date: (expected_date - DATE_TOLERANCE)..(expected_date + DATE_TOLERANCE))
+
+        scope = scope.where(account_id: commitment.account_id) if commitment.account_id.present?
+        scope = scope.where("ABS(entries.amount) BETWEEN ? AND ?", commitment.amount.to_d.abs * 0.5, commitment.amount.to_d.abs * 1.5)
+
+        if commitment.respond_to?(:merchant_id) && commitment.merchant_id.present?
+          fallback_names = [
+            commitment.name,
+            commitment.merchant&.name
+          ].compact.flat_map { |name| [ name, "Subscription: #{name}" ] }
+            .map { |name| name.squish.downcase }
+            .uniq
+
+          scope.joins("INNER JOIN transactions ON transactions.id = entries.entryable_id")
+            .where(
+              "transactions.merchant_id = :merchant_id OR " \
+              "(transactions.merchant_id IS NULL AND LOWER(entries.name) IN (:names))",
+              merchant_id: commitment.merchant_id,
+              names: fallback_names
+            )
+            .order(:date, :created_at)
+            .to_a
+        else
+          scope.where("LOWER(entries.name) = ?", commitment.name.to_s.downcase)
+            .order(:date, :created_at)
+            .to_a
+        end
+      end
+
+      def subscription_scope
+        scope = family.subscription_plans.unarchived
+        return scope unless entry.present?
+
+        scope = scope.where(account_id: entry.account_id, currency: entry.currency)
+        merchant_id = entry.entryable&.merchant_id
+        merchant_id.present? ? scope.where(merchant_id: merchant_id) : scope
+      end
+
+      def recurring_scope
+        scope = family.recurring_transactions
+        return scope unless entry.present?
+
+        scope = scope.where(account_id: entry.account_id, currency: entry.currency)
+        merchant_id = entry.entryable&.merchant_id
+        merchant_id.present? ? scope.where(merchant_id: merchant_id) : scope
+      end
+
+      def classify(entries, expected_date, expected_amount)
+        return "duplicate" if entries.many?
+        return expected_date + MISSING_GRACE < as_of ? "missed" : "pending" if entries.empty?
+
+        difference = (entries.first.amount.to_d.abs - expected_amount.to_d.abs).abs
+        threshold = [ expected_amount.to_d.abs * AMOUNT_TOLERANCE, 1.to_d ].max
+        difference > threshold ? "amount_changed" : "paid"
+      end
+
+      def confidence_for(entries, expected_amount)
+        return 0 if entries.empty?
+        return 65 if entries.many?
+        return 55 if expected_amount.to_d.zero?
+
+        difference = (entries.first.amount.to_d.abs - expected_amount.to_d.abs).abs
+        amount_score = 35 - [ ((difference / expected_amount.to_d.abs) * 100).round, 35 ].min
+        (55 + amount_score).clamp(0, 100)
+      end
+
+      def detail_for(status, entries, expected_amount)
+        case status
+        when "duplicate"
+          "#{entries.size} transactions matched one expected occurrence."
+        when "missed"
+          "No matching transaction arrived within the payment window."
+        when "pending"
+          "The expected date is still within the reconciliation grace period."
+        when "amount_changed"
+          "Expected #{expected_amount.to_d.to_s('F')}, observed #{entries.first.amount.to_d.abs.to_s('F')}."
+        else
+          "Matched to transaction #{entries.first.id}."
+        end
+      end
+
+      def persist!(result)
+        result.entries.each { |entry| link_entry!(entry, result) }
+        if result.commitment.is_a?(SubscriptionPlan) && result.status != "unexpected_renewal"
+          link_subscription_renewal!(result)
+        end
+        record_result_event!(result)
+      end
+
+      def link_entry!(entry, result)
+        transaction = entry.entryable
+        match_key = "#{result.commitment.class.name}:#{result.commitment.id}:#{result.expected_date}"
+        matches = transaction.extra.fetch("recurring_matches", {})
+        return if matches.key?(match_key)
+
+        transaction.with_lock do
+          latest_matches = transaction.extra.fetch("recurring_matches", {})
+          transaction.update!(
+            extra: transaction.extra.merge(
+              "recurring_matches" => latest_matches.merge(
+                match_key => {
+                  "commitment_type" => result.commitment.class.name,
+                  "commitment_id" => result.commitment.id,
+                  "expected_date" => result.expected_date.to_s,
+                  "status" => result.status,
+                  "confidence" => result.confidence,
+                  "reconciled_at" => Time.current.iso8601
+                }
+              )
+            )
+          )
+        end
+      end
+
+      def link_subscription_renewal!(result)
+        subscription = result.commitment
+        renewal = subscription.subscription_renewals.find_or_initialize_by(
+          billing_period_start: result.expected_date
+        )
+
+        if renewal.new_record?
+          renewal.assign_attributes(
+            cycle_number: subscription.next_cycle_number,
+            account_id: subscription.account_id,
+            billing_period_end: subscription.calculate_next_billing_date || result.expected_date,
+            template_amount: subscription.amount,
+            actual_amount: result.entries.first&.amount&.abs || subscription.amount,
+            admin_fee: subscription.default_admin_fee || 0,
+            currency: subscription.currency,
+            status: "pending"
+          )
+        end
+
+        if result.entries.one? && result.status.in?(%w[paid amount_changed])
+          renewal.mark_paid!(
+            paid_at: result.entries.first.date,
+            actual_amount: result.entries.first.amount.abs,
+            entry_id: result.entries.first.id
+          )
+          if subscription.next_billing_at == result.expected_date && subscription.active_or_trial?
+            subscription.mark_as_renewed!(result.entries.first.date)
+          end
+        elsif result.status == "missed"
+          renewal.mark_failed!(notes: result.detail)
+        else
+          renewal.save!
+        end
+      end
+
+      def record_result_event!(result)
+        severity = result.status.in?(%w[missed duplicate amount_changed unexpected_renewal]) ? "warning" : "info"
+        key = "#{result.commitment.class.name}:#{result.commitment.id}:#{result.expected_date}:#{result.status}"
+
+        EventRecorder.record!(
+          record: result.commitment,
+          event: "recurring.#{result.status}",
+          key: key,
+          title: result.status.humanize,
+          detail: result.detail,
+          severity: severity,
+          metadata: {
+            expected_date: result.expected_date,
+            expected_amount: result.expected_amount,
+            observed_amount: result.entries.one? ? result.entries.first.amount.to_d.abs : nil,
+            entry_count: result.entries.size,
+            entry_ids: result.entries.map(&:id),
+            confidence: result.confidence
+          }
+        )
+      end
+  end
+end

--- a/app/models/recurring_transaction.rb
+++ b/app/models/recurring_transaction.rb
@@ -1,21 +1,32 @@
+require "digest"
+
 class RecurringTransaction < ApplicationRecord
   include Monetizable
 
   belongs_to :family
+  belongs_to :account, optional: true
+  belongs_to :destination_account, optional: true, class_name: "Account"
   belongs_to :merchant, optional: true
+  has_many :audit_logs, as: :auditable, dependent: :delete_all
 
   monetize :amount
   monetize :expected_amount_min, allow_nil: true
   monetize :expected_amount_max, allow_nil: true
   monetize :expected_amount_avg, allow_nil: true
 
-  enum :status, { active: "active", inactive: "inactive" }
+  enum :status, { active: "active", inactive: "inactive", ignored: "ignored" }
 
   validates :amount, presence: true
   validates :currency, presence: true
   validates :expected_day_of_month, presence: true, numericality: { greater_than: 0, less_than_or_equal_to: 31 }
+  validates :status, presence: true, inclusion: { in: statuses.keys }
+  validates :occurrence_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :identity_signature, presence: true, uniqueness: { scope: :family_id }, if: -> { has_attribute?(:identity_signature) }
   validate :merchant_or_name_present
   validate :amount_variance_consistency
+  validate :transfer_endpoints_consistent
+
+  before_validation :assign_identity_signature, if: -> { has_attribute?(:identity_signature) }
 
   def merchant_or_name_present
     if merchant_id.blank? && name.blank?
@@ -33,12 +44,56 @@ class RecurringTransaction < ApplicationRecord
     end
   end
 
+  def transfer_endpoints_consistent
+    return if destination_account_id.blank?
+
+    if account.blank?
+      errors.add(:account, "must exist")
+    elsif destination_account.blank?
+      errors.add(:destination_account, "must exist")
+    elsif account_id == destination_account_id
+      errors.add(:destination_account, "cannot be the same as the source account")
+    elsif account.family_id != destination_account.family_id || family_id != account.family_id
+      errors.add(:destination_account, "must belong to the same family as the source account")
+    end
+  end
+
+  def transfer?
+    destination_account_id.present?
+  end
+
+  def schedule
+    Recurring::Schedule.from_recurring_transaction(self)
+  end
+
+  def self.identity_signature_for(account_id:, destination_account_id:, merchant_id:, name:, amount:, currency:)
+    return nil if amount.blank? || currency.blank?
+
+    normalized_name = name.to_s.squish.downcase
+    normalized_amount = BigDecimal(amount.to_s).round(2).to_s("F")
+    raw_identity = [
+      "source:#{account_id || 'any'}",
+      "destination:#{destination_account_id || 'none'}",
+      "merchant:#{merchant_id || 'none'}",
+      "name:#{normalized_name}",
+      "amount:#{normalized_amount}",
+      "currency:#{currency.to_s.upcase}"
+    ].join("|")
+
+    Digest::SHA256.hexdigest(raw_identity)
+  end
+
   scope :for_family, ->(family) { where(family: family) }
+  scope :visible, -> { where.not(status: "ignored") }
   scope :expected_soon, -> { active.where("next_expected_date <= ?", 1.month.from_now) }
 
   # Class methods for identification and cleanup
   def self.identify_patterns_for(family)
     Identifier.new(family).identify_recurring_patterns
+  end
+
+  def self.schedule_identification_for(family)
+    IdentifyRecurringTransactionsJob.schedule_for(family)
   end
 
   def self.cleanup_stale_for(family)
@@ -59,9 +114,11 @@ class RecurringTransaction < ApplicationRecord
     # Look back 6 months
     start_date = 6.months.ago.to_date
 
-    query = family.entries
+    query = entry.account.entries
+      .joins(transaction_join_sql)
       .where(entryable_type: "Transaction")
       .where(currency: entry.currency)
+      .where.not(transactions: { kind: Transaction::TRANSFER_KINDS })
       .where("entries.date >= ?", start_date)
       .where("entries.date <= ?", entry.date)
       .where("EXTRACT(DAY FROM entries.date) BETWEEN ? AND ?",
@@ -69,13 +126,9 @@ class RecurringTransaction < ApplicationRecord
              [ day_of_month + 5, 31 ].min)
 
     if merchant.present?
-      # Match by merchant
-      matching_entries = query.select do |e|
-        e.entryable.is_a?(Transaction) && e.entryable.merchant_id == merchant.id
-      end
+      matching_entries = query.where(transactions: { merchant_id: merchant.id }).to_a
     else
-      # Match by name
-      matching_entries = query.where(name: entry.name)
+      matching_entries = query.where(name: entry.name).to_a
     end
 
     # Include the current transaction if not already in list
@@ -92,6 +145,7 @@ class RecurringTransaction < ApplicationRecord
     # Create the recurring transaction
     create!(
       family: family,
+      account: entry.account,
       merchant: merchant,
       name: merchant.present? ? nil : entry.name,
       amount: entry.amount, # Use current amount as base
@@ -108,11 +162,47 @@ class RecurringTransaction < ApplicationRecord
     )
   end
 
+  def self.create_from_transfer(transfer)
+    outflow_entry = transfer.outflow_transaction&.entry
+    inflow_entry = transfer.inflow_transaction&.entry
+    raise ArgumentError, "Transfer is missing one of its entries" unless outflow_entry && inflow_entry
+
+    source_account = outflow_entry.account
+    destination_account = inflow_entry.account
+    raise ArgumentError, "Transfer accounts must belong to the same family" unless source_account.family_id == destination_account.family_id
+
+    create!(
+      family: source_account.family,
+      account: source_account,
+      destination_account: destination_account,
+      name: transfer.name,
+      amount: outflow_entry.amount,
+      currency: outflow_entry.currency,
+      expected_day_of_month: outflow_entry.date.day,
+      last_occurrence_date: outflow_entry.date,
+      next_expected_date: next_date_for_day(outflow_entry.date.day),
+      occurrence_count: 1,
+      status: "active",
+      manual: true
+    )
+  end
+
+  def self.next_date_for_day(day, from: Date.current)
+    next_month = from.next_month
+    Date.new(next_month.year, next_month.month, day)
+  rescue ArgumentError
+    next_month.end_of_month
+  end
+
   # Find matching transactions for this recurring pattern
   def matching_transactions
-    entries = family.entries
+    return transfer_matching_transactions if transfer?
+
+    entries = (account || family).entries
+      .joins(self.class.transaction_join_sql)
       .where(entryable_type: "Transaction")
       .where(currency: currency)
+      .where.not(transactions: { kind: Transaction::TRANSFER_KINDS })
 
     # For manual recurring transactions, we allow amount variance
     if manual? && expected_amount_min.present? && expected_amount_max.present?
@@ -132,18 +222,23 @@ class RecurringTransaction < ApplicationRecord
 
     # Filter by merchant or name
     if merchant_id.present?
-      # Match by merchant through the entryable (Transaction)
-      entries.select do |entry|
-        entry.entryable.is_a?(Transaction) && entry.entryable.merchant_id == merchant_id
-      end
+      entries.where(transactions: { merchant_id: merchant_id })
     else
-      # Match by entry name
       entries.where(name: name)
     end
   end
 
+  def self.transaction_join_sql
+    <<~SQL.squish
+      INNER JOIN transactions
+        ON transactions.id = entries.entryable_id
+        AND entries.entryable_type = 'Transaction'
+    SQL
+  end
+
   # Check if this recurring transaction should be marked inactive
   def should_be_inactive?
+    return false if ignored?
     return false if last_occurrence_date.nil?
     last_occurrence_date < 2.months.ago
   end
@@ -158,9 +253,123 @@ class RecurringTransaction < ApplicationRecord
     update!(status: "active")
   end
 
+  def ignore!
+    ActiveRecord::Base.transaction do
+      create_suppression!
+      update!(status: "ignored")
+    end
+  end
+
+  def restore!
+    ActiveRecord::Base.transaction do
+      RecurringTransactionSuppression.where(
+        family: family,
+        signature: suppression_signatures
+      ).delete_all
+      update!(status: "active")
+    end
+  end
+
+  def confirm_as_recurring!
+    with_lock do
+      update!(manual: true, status: "active")
+      Recurring::EventRecorder.record!(
+        record: self,
+        event: "recurring.confirmed",
+        key: "confirmed",
+        title: "Confirmed recurring pattern",
+        detail: "User confirmed this detected pattern as a recurring commitment.",
+        metadata: { confidence: Recurring::Assessment.new(self).score }
+      )
+    end
+  end
+
+  def recurring_assessment
+    Recurring::Assessment.new(self)
+  end
+
+  def mark_as_transfer!(destination_account)
+    raise ArgumentError, "A source account is required" if account.blank?
+    raise ArgumentError, "Destination account must belong to the same family" if destination_account&.family_id != family_id
+    raise ArgumentError, "Destination account must differ from source account" if destination_account.id == account_id
+
+    with_lock do
+      update!(
+        destination_account: destination_account,
+        manual: true,
+        status: "active"
+      )
+      Recurring::EventRecorder.record!(
+        record: self,
+        event: "recurring.classified_transfer",
+        key: "classified-transfer:#{destination_account.id}",
+        title: "Classified as recurring transfer",
+        detail: "This pattern now tracks transfers from #{account.name} to #{destination_account.name}.",
+        metadata: {
+          source_account_id: account_id,
+          destination_account_id: destination_account.id
+        }
+      )
+    end
+  end
+
+  def create_subscription_plan!
+    raise ArgumentError, "Only recurring expenses can become subscription plans" unless subscription_candidate?
+
+    existing = matching_subscription_plan
+
+    ActiveRecord::Base.transaction do
+      if existing
+        ignore!
+        existing
+      else
+        plan = family.subscription_plans.create!(
+          account: inferred_account!,
+          merchant: merchant,
+          name: subscription_name,
+          amount: amount,
+          currency: currency,
+          billing_cycle: "monthly",
+          status: "active",
+          payment_method: "manual",
+          started_at: last_occurrence_date,
+          next_billing_at: next_expected_date,
+          auto_renew: true,
+          metadata: {
+            source: {
+              type: self.class.name,
+              id: id,
+              converted_at: Time.current.iso8601
+            }
+          }
+        )
+
+        ignore!
+        plan
+      end
+    end
+  end
+
+  def subscription_candidate?
+    !transfer? && amount.positive? && next_expected_date.present? && last_occurrence_date.present?
+  end
+
+  def suppressed_signature?
+    RecurringTransactionSuppression.suppressed?(
+      family: family,
+      account_id: account_id,
+      merchant_id: merchant_id,
+      name: name,
+      amount: amount,
+      currency: currency
+    )
+  end
+
   # Update based on a new transaction occurrence
   # Update based on a new transaction occurrence
   def record_occurrence!(transaction_date, transaction_amount = nil)
+    return false if ignored?
+
     self.last_occurrence_date = transaction_date
     self.next_expected_date = calculate_next_expected_date(transaction_date)
     self.occurrence_count += 1
@@ -210,7 +419,10 @@ class RecurringTransaction < ApplicationRecord
       merchant: merchant,
       name: merchant.present? ? merchant.name : name,
       recurring: true,
-      projected: true
+      projected: true,
+      transfer: transfer?,
+      source_account: account,
+      destination_account: destination_account
     )
   end
 
@@ -221,7 +433,93 @@ class RecurringTransaction < ApplicationRecord
   end
 
   private
+    def transfer_matching_transactions
+      return Entry.none unless account && destination_account
+
+      source_entries = account.entries
+        .where(entryable_type: "Transaction", currency: currency, amount: amount)
+        .where(
+          "EXTRACT(DAY FROM entries.date) BETWEEN ? AND ?",
+          [ expected_day_of_month - 2, 1 ].max,
+          [ expected_day_of_month + 2, 31 ].min
+        )
+
+      paired_transaction_ids = Transfer
+        .where(outflow_transaction_id: source_entries.select(:entryable_id))
+        .where(
+          inflow_transaction_id: destination_account.entries
+            .where(entryable_type: "Transaction")
+            .select(:entryable_id)
+        )
+        .pluck(:outflow_transaction_id)
+
+      source_entries.where(entryable_id: paired_transaction_ids).order(date: :desc)
+    end
+
+    def assign_identity_signature
+      self.identity_signature = self.class.identity_signature_for(
+        account_id: account_id,
+        destination_account_id: destination_account_id,
+        merchant_id: merchant_id,
+        name: name,
+        amount: amount,
+        currency: currency
+      )
+    end
+
+    def subscription_name
+      merchant&.name || name
+    end
+
+    def inferred_account!
+      inferred_account = account || Array(matching_transactions).max_by(&:date)&.account
+      inferred_account ||= family.accounts.first
+      raise ArgumentError, "Cannot create subscription without a payment account" unless inferred_account
+
+      inferred_account
+    end
+
+    def matching_subscription_plan
+      scope = family.subscription_plans.unarchived
+
+      if merchant_id.present?
+        scope.find_by(merchant_id: merchant_id)
+      else
+        scope.where("LOWER(name) = ?", subscription_name.to_s.downcase)
+          .find_by(amount: amount, currency: currency)
+      end
+    end
+
     def monetizable_currency
       currency
+    end
+
+    def create_suppression!
+      RecurringTransactionSuppression.suppress!(
+        family: family,
+        account_id: account_id,
+        destination_account_id: destination_account_id,
+        merchant_id: merchant_id,
+        name: name,
+        amount: amount,
+        currency: currency,
+        expected_day_of_month: expected_day_of_month,
+        metadata: {
+          recurring_transaction_id: id
+        }.compact
+      )
+    end
+
+    def suppression_signatures
+      [ account_id, nil ].uniq.filter_map do |suppression_account_id|
+        RecurringTransactionSuppression.signature_for(
+          account_id: suppression_account_id,
+          destination_account_id: destination_account_id,
+          merchant_id: merchant_id,
+          name: name,
+          amount: amount,
+          currency: currency
+        )
+      end
     end
 end

--- a/app/models/recurring_transaction/identifier.rb
+++ b/app/models/recurring_transaction/identifier.rb
@@ -12,46 +12,52 @@ class RecurringTransaction
 
       # Get all transactions from the last 3 months
       entries_with_transactions = family.entries
+        .joins(RecurringTransaction.transaction_join_sql)
         .where(entryable_type: "Transaction")
         .where("entries.date >= ?", three_months_ago)
+        .where.not(transactions: { kind: Transaction::TRANSFER_KINDS })
         .includes(:entryable)
         .to_a
 
-      # Group by merchant (if present) or name, along with amount (preserve sign) and currency
+      # Group by account, merchant/name, amount (preserve sign), and currency.
       grouped_transactions = entries_with_transactions
         .select { |entry| entry.entryable.is_a?(Transaction) }
         .group_by do |entry|
           transaction = entry.entryable
           # Use merchant_id if present, otherwise use entry name
           identifier = transaction.merchant_id.present? ? [ :merchant, transaction.merchant_id ] : [ :name, entry.name ]
-          [ identifier, entry.amount.round(2), entry.currency ]
+          [ entry.account_id, identifier, entry.amount.round(2), entry.currency ]
         end
 
       recurring_patterns = []
 
-      grouped_transactions.each do |(identifier, amount, currency), entries|
+      grouped_transactions.each do |(account_id, identifier, amount, currency), entries|
         next if entries.size < 3  # Must have at least 3 occurrences
 
         # Check if the last occurrence was within the last 45 days
         last_occurrence = entries.max_by(&:date)
         next if last_occurrence.date < 45.days.ago.to_date
 
-        # Check if transactions occur on similar days (within 5 days of each other)
+        cadence = calculate_short_cadence(entries)
+
+        # Monthly patterns cluster by day-of-month. Short schedules instead use
+        # stable day gaps and require at least four occurrences.
         days_of_month = entries.map { |e| e.date.day }.sort
 
-        # Calculate if days cluster together (standard deviation check)
-        if days_cluster_together?(days_of_month)
+        if cadence.present? || days_cluster_together?(days_of_month)
           expected_day = calculate_expected_day(days_of_month)
 
           # Unpack identifier - either [:merchant, id] or [:name, name_string]
           identifier_type, identifier_value = identifier
 
           pattern = {
+            account_id: account_id,
             amount: amount,
             currency: currency,
             expected_day_of_month: expected_day,
             last_occurrence_date: last_occurrence.date,
             occurrence_count: entries.size,
+            cadence_days: cadence,
             entries: entries
           }
 
@@ -66,10 +72,13 @@ class RecurringTransaction
         end
       end
 
+      processed_count = 0
+
       # Create or update RecurringTransaction records
       recurring_patterns.each do |pattern|
         # Build find conditions based on whether it's merchant-based or name-based
         find_conditions = {
+          account_id: pattern[:account_id],
           amount: pattern[:amount],
           currency: pattern[:currency]
         }
@@ -85,32 +94,63 @@ class RecurringTransaction
         # Check if a manual recurring transaction already exists for this pattern
         # If so, we skip auto-creation to avoid duplicates, but we might want to update stats?
         # For now, let's assume manual overrides auto
-        existing_manual = family.recurring_transactions.find_by(find_conditions.merge(manual: true))
-        next if existing_manual
+        legacy_find_conditions = find_conditions.merge(account_id: nil)
+        existing_manual =
+          family.recurring_transactions.find_by(find_conditions.merge(manual: true)) ||
+          family.recurring_transactions.find_by(legacy_find_conditions.merge(manual: true))
 
-        recurring_transaction = family.recurring_transactions.find_or_initialize_by(find_conditions)
+        if existing_manual
+          existing_manual.update!(account_id: pattern[:account_id]) if existing_manual.account_id.blank?
+          next
+        end
+
+        recurring_transaction =
+          family.recurring_transactions.find_by(find_conditions) ||
+          family.recurring_transactions.find_by(legacy_find_conditions)
+
+        if recurring_transaction.nil? && RecurringTransactionSuppression.suppressed?(
+          family: family,
+          account_id: pattern[:account_id],
+          merchant_id: pattern[:merchant_id],
+          name: pattern[:name],
+          amount: pattern[:amount],
+          currency: pattern[:currency]
+        )
+          next
+        end
+
+        recurring_transaction ||= family.recurring_transactions.new(find_conditions)
 
         # Set the name or merchant_id on new records
         if recurring_transaction.new_record?
+          recurring_transaction.account_id = pattern[:account_id]
+
           if pattern[:merchant_id].present?
             recurring_transaction.merchant_id = pattern[:merchant_id]
           else
             recurring_transaction.name = pattern[:name]
           end
+        elsif recurring_transaction.account_id.blank?
+          recurring_transaction.account_id = pattern[:account_id]
         end
 
         recurring_transaction.assign_attributes(
           expected_day_of_month: pattern[:expected_day_of_month],
           last_occurrence_date: pattern[:last_occurrence_date],
-          next_expected_date: calculate_next_expected_date(pattern[:last_occurrence_date], pattern[:expected_day_of_month]),
+          next_expected_date: calculate_next_expected_date(
+            pattern[:last_occurrence_date],
+            pattern[:expected_day_of_month],
+            cadence_days: pattern[:cadence_days]
+          ),
           occurrence_count: pattern[:occurrence_count],
-          status: "active"
+          status: recurring_transaction.new_record? ? "active" : recurring_transaction.status
         )
 
         recurring_transaction.save!
+        processed_count += 1
       end
 
-      recurring_patterns.size
+      processed_count
     end
 
     private
@@ -132,6 +172,18 @@ class RecurringTransaction
 
         # Allow up to 5 days standard deviation
         std_dev <= 5
+      end
+
+      def calculate_short_cadence(entries)
+        return nil if entries.size < 4
+
+        dates = entries.map(&:date).sort
+        gaps = dates.each_cons(2).map { |previous_date, date| (date - previous_date).to_i }
+        median = gaps.sort[gaps.size / 2]
+        return nil unless median.between?(1, 27)
+        return nil unless gaps.all? { |gap| (gap - median).abs <= 2 }
+
+        median
       end
 
       # Calculate circular distance between two days on a 31-day circle
@@ -186,7 +238,9 @@ class RecurringTransaction
       end
 
       # Calculate next expected date
-      def calculate_next_expected_date(last_date, expected_day)
+      def calculate_next_expected_date(last_date, expected_day, cadence_days: nil)
+        return last_date + cadence_days.days if cadence_days.present?
+
         next_month = last_date.next_month
 
         begin

--- a/app/models/recurring_transaction_suppression.rb
+++ b/app/models/recurring_transaction_suppression.rb
@@ -1,0 +1,95 @@
+class RecurringTransactionSuppression < ApplicationRecord
+  belongs_to :family
+  belongs_to :account, optional: true
+  belongs_to :destination_account, optional: true, class_name: "Account"
+  belongs_to :merchant, optional: true
+
+  validates :amount, presence: true
+  validates :currency, presence: true
+  validates :signature, presence: true, uniqueness: { scope: :family_id }
+  validate :merchant_or_name_present
+
+  before_validation :assign_signature
+
+  def self.signature_for(account_id:, destination_account_id: nil, merchant_id:, name:, amount:, currency:)
+    return nil if amount.blank? || currency.blank?
+
+    normalized_name = name.to_s.squish.downcase
+    normalized_amount = BigDecimal(amount.to_s).round(2).to_s("F")
+
+    [
+      "account:#{account_id || 'any'}",
+      "destination:#{destination_account_id || 'none'}",
+      "merchant:#{merchant_id || 'none'}",
+      "name:#{normalized_name}",
+      "amount:#{normalized_amount}",
+      "currency:#{currency}"
+    ].join("|")
+  end
+
+  def self.suppressed?(family:, account_id:, destination_account_id: nil, merchant_id:, name:, amount:, currency:)
+    signature = signature_for(
+      account_id: account_id,
+      destination_account_id: destination_account_id,
+      merchant_id: merchant_id,
+      name: name,
+      amount: amount,
+      currency: currency
+    )
+
+    legacy_signature = signature_for(
+      account_id: nil,
+      destination_account_id: destination_account_id,
+      merchant_id: merchant_id,
+      name: name,
+      amount: amount,
+      currency: currency
+    )
+
+    where(family: family, signature: [ signature, legacy_signature ]).exists?
+  end
+
+  def self.suppress!(family:, account_id:, destination_account_id: nil, merchant_id:, name:, amount:, currency:, expected_day_of_month: nil, reason: "user_ignored", metadata: {})
+    signature = signature_for(
+      account_id: account_id,
+      destination_account_id: destination_account_id,
+      merchant_id: merchant_id,
+      name: name,
+      amount: amount,
+      currency: currency
+    )
+
+    create_with(
+      account_id: account_id,
+      destination_account_id: destination_account_id,
+      merchant_id: merchant_id,
+      name: name,
+      amount: amount,
+      currency: currency,
+      expected_day_of_month: expected_day_of_month,
+      reason: reason,
+      metadata: metadata
+    ).find_or_create_by!(family: family, signature: signature)
+  end
+
+  private
+
+    def assign_signature
+      return if amount.blank? || currency.blank?
+
+      self.signature ||= self.class.signature_for(
+        account_id: account_id,
+        destination_account_id: destination_account_id,
+        merchant_id: merchant_id,
+        name: name,
+        amount: amount,
+        currency: currency
+      )
+    end
+
+    def merchant_or_name_present
+      return if merchant_id.present? || name.present?
+
+      errors.add(:base, "Either merchant or name must be present")
+    end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,15 @@
 <% mobile_nav_items = [
   { name: "Home", path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) },
   { name: "Transactions", path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
-  { name: "Subscriptions", path: subscription_plans_path, icon: "repeat", icon_custom: false, active: page_active?(subscription_plans_path) },
+  {
+    name: "Recurring",
+    path: recurring_path,
+    icon: "repeat",
+    icon_custom: false,
+    active: request.path == recurring_path ||
+      request.path.start_with?(subscription_plans_path) ||
+      request.path.start_with?(recurring_transactions_path)
+  },
   { name: "Budgets", path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
   { name: "Reports", path: reports_path, icon: "chart-bar", icon_custom: false, active: page_active?(reports_path) }
 ] %>
@@ -139,7 +147,7 @@
         <%= render "layouts/shared/nav_item", **nav_item %>
       <% end %>
     <% end %>
-    
+
     <%# Floating AI Chat - At body level for proper z-index stacking (z-40 button, z-50 panel) %>
     <div data-print="hide">
       <%= render FloatingChatComponent.new(user: Current.user) %>

--- a/app/views/recurring/_navigation.html.erb
+++ b/app/views/recurring/_navigation.html.erb
@@ -1,0 +1,24 @@
+<%# locals: (current:) %>
+<% items = [
+  { key: "overview", label: "Overview", icon: "layout-dashboard", path: recurring_path },
+  { key: "subscriptions", label: "Subscriptions", icon: "wallet-cards", path: subscription_plans_path },
+  { key: "detected", label: "Detected", icon: "search", path: recurring_transactions_path },
+  { key: "transfers", label: "Transfers", icon: "arrow-left-right", path: recurring_transactions_path(kind: "transfers") },
+  { key: "ignored", label: "Ignored", icon: "eye-off", path: recurring_transactions_path(kind: "ignored") }
+] %>
+
+<nav class="mb-6 overflow-x-auto" aria-label="Recurring workspace">
+  <div class="inline-flex min-w-full gap-1 rounded-[24px] bg-container-inset p-1 shadow-border-xs sm:min-w-0">
+    <% items.each do |item| %>
+      <%= link_to item[:path],
+          class: class_names(
+            "inline-flex min-h-11 flex-1 items-center justify-center gap-2 whitespace-nowrap rounded-[20px] px-4 py-2 text-sm font-semibold transition-colors sm:flex-none",
+            item[:key] == current ? "bg-container text-primary shadow-border-xs" : "text-secondary hover:bg-surface-hover hover:text-primary"
+          ),
+          aria: { current: ("page" if item[:key] == current) } do %>
+        <%= icon item[:icon], class: "h-4 w-4" %>
+        <%= item[:label] %>
+      <% end %>
+    <% end %>
+  </div>
+</nav>

--- a/app/views/recurring/index.html.erb
+++ b/app/views/recurring/index.html.erb
@@ -1,0 +1,212 @@
+<div class="mx-auto max-w-[1240px] px-4 py-6 lg:px-8">
+  <%= render "recurring/navigation", current: "overview" %>
+
+  <header class="mb-8">
+    <p class="text-sm font-semibold text-secondary">Recurring money control</p>
+    <h1 class="mt-2 text-4xl font-black leading-none text-primary lg:text-5xl">Recurring</h1>
+    <p class="mt-3 max-w-3xl text-base text-secondary lg:text-lg">
+      Review detected patterns, manage subscription lifecycles, and track scheduled transfers from one workspace.
+    </p>
+  </header>
+
+  <section class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4" aria-label="Recurring summary">
+    <%= link_to subscription_plans_path, class: "rounded-[24px] bg-container p-5 shadow-border-xs transition-colors hover:bg-surface-hover" do %>
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-medium text-secondary">Monthly subscriptions</span>
+        <%= icon "wallet-cards", class: "h-5 w-5 text-secondary" %>
+      </div>
+      <p class="mt-3 text-3xl font-black text-primary"><%= number_to_currency(@monthly_commitment, unit: "#{Current.family.currency} ") %></p>
+      <p class="mt-2 text-xs text-secondary"><%= @active_subscriptions.count %> active subscriptions</p>
+    <% end %>
+
+    <%= link_to recurring_transactions_path, class: "rounded-[24px] bg-container p-5 shadow-border-xs transition-colors hover:bg-surface-hover" do %>
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-medium text-secondary">Detected patterns</span>
+        <%= icon "search", class: "h-5 w-5 text-secondary" %>
+      </div>
+      <p class="mt-3 text-3xl font-black text-primary"><%= @detected_count %></p>
+      <p class="mt-2 text-xs text-secondary">Ready for review</p>
+    <% end %>
+
+    <%= link_to recurring_transactions_path(kind: "transfers"), class: "rounded-[24px] bg-container p-5 shadow-border-xs transition-colors hover:bg-surface-hover" do %>
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-medium text-secondary">Recurring transfers</span>
+        <%= icon "arrow-left-right", class: "h-5 w-5 text-secondary" %>
+      </div>
+      <p class="mt-3 text-3xl font-black text-primary"><%= @transfer_count %></p>
+      <p class="mt-2 text-xs text-secondary">Between your accounts</p>
+    <% end %>
+
+    <%= link_to recurring_transactions_path(kind: "ignored"), class: "rounded-[24px] bg-container p-5 shadow-border-xs transition-colors hover:bg-surface-hover" do %>
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-medium text-secondary">Ignored patterns</span>
+        <%= icon "eye-off", class: "h-5 w-5 text-secondary" %>
+      </div>
+      <p class="mt-3 text-3xl font-black text-primary"><%= @ignored_count %></p>
+      <p class="mt-2 text-xs text-secondary">Suppressed from detection</p>
+    <% end %>
+  </section>
+
+  <section class="mt-8 grid grid-cols-1 gap-4 xl:grid-cols-2">
+    <div class="overflow-hidden rounded-[24px] bg-container shadow-border-xs">
+      <div class="flex items-center justify-between border-b border-primary px-6 py-5">
+        <div>
+          <h2 class="text-xl font-semibold text-primary">Upcoming subscriptions</h2>
+          <p class="mt-1 text-sm text-secondary">Next managed billing dates</p>
+        </div>
+        <%= link_to "View all", subscription_plans_path, class: "text-sm font-semibold text-link hover:underline" %>
+      </div>
+      <div class="divide-y divide-tertiary">
+        <% @upcoming_subscriptions.each do |subscription| %>
+          <%= link_to subscription_plan_path(subscription), class: "flex items-center justify-between gap-4 px-6 py-4 hover:bg-surface-hover" do %>
+            <div class="min-w-0">
+              <p class="truncate font-medium text-primary"><%= subscription.name %></p>
+              <p class="mt-1 text-xs text-secondary"><%= subscription.formatted_billing_cycle %></p>
+            </div>
+            <div class="shrink-0 text-right">
+              <p class="font-semibold text-primary"><%= subscription.formatted_amount %></p>
+              <p class="mt-1 text-xs text-secondary"><%= subscription.next_billing_at.strftime("%b %d, %Y") %></p>
+            </div>
+          <% end %>
+        <% end %>
+        <% if @upcoming_subscriptions.empty? %>
+          <p class="px-6 py-10 text-center text-sm text-secondary">No upcoming subscription billing.</p>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="overflow-hidden rounded-[24px] bg-container shadow-border-xs">
+      <div class="flex items-center justify-between border-b border-primary px-6 py-5">
+        <div>
+          <h2 class="text-xl font-semibold text-primary">Expected recurring activity</h2>
+          <p class="mt-1 text-sm text-secondary">Detected payments and transfers</p>
+        </div>
+        <%= link_to "Review", recurring_transactions_path, class: "text-sm font-semibold text-link hover:underline" %>
+      </div>
+      <div class="divide-y divide-tertiary">
+        <% @upcoming_patterns.each do |recurring_transaction| %>
+          <%= link_to recurring_transactions_path(kind: recurring_transaction.transfer? ? "transfers" : nil),
+              class: "flex items-center justify-between gap-4 px-6 py-4 hover:bg-surface-hover" do %>
+            <div class="min-w-0">
+              <p class="truncate font-medium text-primary"><%= recurring_transaction.name %></p>
+              <p class="mt-1 text-xs text-secondary"><%= recurring_transaction.transfer? ? "Transfer" : "Detected pattern" %></p>
+            </div>
+            <div class="shrink-0 text-right">
+              <p class="font-semibold text-primary"><%= format_money(-recurring_transaction.amount_money) %></p>
+              <p class="mt-1 text-xs text-secondary"><%= recurring_transaction.next_expected_date.strftime("%b %d, %Y") %></p>
+            </div>
+          <% end %>
+        <% end %>
+        <% if @upcoming_patterns.empty? %>
+          <p class="px-6 py-10 text-center text-sm text-secondary">No recurring activity detected yet.</p>
+        <% end %>
+      </div>
+    </div>
+  </section>
+
+  <section class="mt-8 grid grid-cols-1 gap-4 xl:grid-cols-[1.35fr_0.65fr]">
+    <div class="overflow-hidden rounded-[24px] bg-container shadow-border-xs">
+      <div class="flex items-center justify-between border-b border-primary px-6 py-5">
+        <div>
+          <h2 class="text-xl font-semibold text-primary">30-day cash-flow forecast</h2>
+          <p class="mt-1 text-sm text-secondary">Actual transactions are excluded to prevent double counting.</p>
+        </div>
+        <p class="text-lg font-black text-primary">
+          <%= number_to_currency(@forecast.projected_outflow, unit: "#{Current.family.currency} ") %>
+        </p>
+      </div>
+
+      <div class="divide-y divide-tertiary">
+        <% @forecast_items.each do |item| %>
+          <div class="flex items-center justify-between gap-4 px-6 py-4">
+            <div class="flex min-w-0 items-center gap-3">
+              <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-container-inset text-secondary">
+                <%= icon item.kind == "transfer" ? "arrow-left-right" : "calendar-clock", class: "h-4 w-4" %>
+              </div>
+              <div class="min-w-0">
+                <p class="truncate font-medium text-primary"><%= item.commitment.name %></p>
+                <p class="mt-1 text-xs text-secondary"><%= item.kind.humanize %> · <%= item.date.strftime("%b %d") %></p>
+              </div>
+            </div>
+            <p class="shrink-0 font-semibold text-primary">
+              <%= number_to_currency(item.amount, unit: "#{item.currency} ") %>
+            </p>
+          </div>
+        <% end %>
+        <% if @forecast_items.empty? %>
+          <p class="px-6 py-10 text-center text-sm text-secondary">No projected recurring outflow in the next 30 days.</p>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="overflow-hidden rounded-[24px] bg-container shadow-border-xs">
+      <div class="border-b border-primary px-6 py-5">
+        <h2 class="text-xl font-semibold text-primary">Attention feed</h2>
+        <p class="mt-1 text-sm text-secondary">Reconciliation and lifecycle history</p>
+      </div>
+
+      <div class="divide-y divide-tertiary">
+        <% @recent_events.each do |event| %>
+          <% metadata = event.changeset.fetch("metadata", {}) %>
+          <% commitment = event.auditable %>
+          <div class="px-6 py-4" data-recurring-event>
+            <div class="flex items-start gap-3">
+              <span class="mt-1.5 h-2 w-2 shrink-0 rounded-full <%= event.changeset["severity"] == "warning" ? "bg-warning" : "bg-success" %>"></span>
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-semibold text-primary">
+                  <%= event.changeset["title"] || event.event.humanize %>
+                  <% if commitment.present? %>
+                    <span class="text-secondary">·</span>
+                    <%= commitment.name %>
+                  <% end %>
+                </p>
+                <p class="mt-1 text-xs text-secondary"><%= event.changeset["detail"] %></p>
+                <% if metadata["expected_date"].present? || metadata["expected_amount"].present? %>
+                  <dl class="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                    <% if metadata["expected_date"].present? %>
+                      <div>
+                        <dt class="text-secondary">Expected date</dt>
+                        <dd class="mt-0.5 font-medium text-primary"><%= l(Date.parse(metadata["expected_date"].to_s), format: :short) %></dd>
+                      </div>
+                    <% end %>
+                    <% if metadata["expected_amount"].present? %>
+                      <div>
+                        <dt class="text-secondary">Expected</dt>
+                        <dd class="mt-0.5 font-medium text-primary">
+                          <%= number_to_currency(metadata["expected_amount"], unit: "#{commitment&.currency || Current.family.currency} ") %>
+                        </dd>
+                      </div>
+                    <% end %>
+                    <% if metadata["observed_amount"].present? %>
+                      <div>
+                        <dt class="text-secondary">Observed</dt>
+                        <dd class="mt-0.5 font-medium text-primary">
+                          <%= number_to_currency(metadata["observed_amount"], unit: "#{commitment&.currency || Current.family.currency} ") %>
+                        </dd>
+                      </div>
+                    <% elsif metadata["entry_count"].to_i > 1 %>
+                      <div>
+                        <dt class="text-secondary">Matched transactions</dt>
+                        <dd class="mt-0.5 font-medium text-primary"><%= metadata["entry_count"] %></dd>
+                      </div>
+                    <% end %>
+                    <% if commitment&.respond_to?(:account) && commitment.account.present? %>
+                      <div>
+                        <dt class="text-secondary">Account</dt>
+                        <dd class="mt-0.5 truncate font-medium text-primary"><%= commitment.account.name %></dd>
+                      </div>
+                    <% end %>
+                  </dl>
+                <% end %>
+                <p class="mt-2 text-xs text-secondary"><%= time_ago_in_words(event.created_at) %> ago</p>
+              </div>
+            </div>
+          </div>
+        <% end %>
+        <% if @recent_events.empty? %>
+          <p class="px-6 py-10 text-center text-sm text-secondary">No recurring events recorded yet.</p>
+        <% end %>
+      </div>
+    </div>
+  </section>
+</div>

--- a/app/views/recurring_transactions/index.html.erb
+++ b/app/views/recurring_transactions/index.html.erb
@@ -1,49 +1,39 @@
-<div class="space-y-4 flex flex-col">
-  <header class="flex justify-between items-center text-primary font-medium">
-    <h1 class="text-xl"><%= t("recurring_transactions.title") %></h1>
-    <div class="flex items-center gap-2">
-      <%= render DS::Menu.new do |menu| %>
-        <% menu.with_item(
-            variant: "button",
-            text: t("recurring_transactions.cleanup_stale"),
-            href: cleanup_recurring_transactions_path,
-            method: :post,
-            icon: "trash-2") %>
-      <% end %>
-      <%= render DS::Link.new(
-        text: t("recurring_transactions.identify_patterns"),
-        icon: "search",
-        variant: "outline",
-        href: identify_recurring_transactions_path,
-        method: :post
-      ) %>
-    </div>
-  </header>
+<% view_config = {
+  "detected" => {
+    title: "Detected recurring",
+    description: "Review patterns found in transaction history and promote real subscriptions.",
+    icon: "search",
+    empty_title: "No recurring patterns detected",
+    empty_description: "Run detection after importing or syncing transaction history."
+  },
+  "transfers" => {
+    title: "Recurring transfers",
+    description: "Track repeating movements between accounts separately from merchant payments.",
+    icon: "arrow-left-right",
+    empty_title: "No recurring transfers",
+    empty_description: "Mark an existing transfer as recurring from its transaction detail page."
+  },
+  "ignored" => {
+    title: "Ignored patterns",
+    description: "Suppressed patterns stay here and will not be recreated by automatic detection.",
+    icon: "eye-off",
+    empty_title: "No ignored patterns",
+    empty_description: "Patterns you dismiss will appear here and can be restored later."
+  }
+}.fetch(@recurring_view) %>
 
-  <div class="p-4 bg-container-inset border border-secondary rounded-lg">
-    <div class="flex items-start gap-2">
-      <%= icon "info", class: "w-5 h-5 text-link mt-0.5 flex-shrink-0" %>
-      <div>
-        <p class="text-sm font-medium text-primary mb-2"><%= t("recurring_transactions.info.title") %></p>
-        <p class="text-xs text-secondary mb-2"><%= t("recurring_transactions.info.manual_description") %></p>
-        <p class="text-xs text-secondary mb-1"><%= t("recurring_transactions.info.automatic_description") %></p>
-        <ul class="list-disc list-inside text-xs text-secondary space-y-0.5 ml-2">
-          <% t("recurring_transactions.info.triggers").each do |trigger| %>
-            <li><%= trigger %></li>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-  </div>
+<div class="mx-auto max-w-[1240px] px-4 py-6 lg:px-8">
+  <%= render "recurring/navigation", current: @recurring_view %>
 
-  <div class="bg-container rounded-xl shadow-border-xs p-4">
-    <% if @recurring_transactions.empty? %>
-      <div class="text-center py-12">
-        <div class="text-secondary mb-4">
-          <%= icon "repeat", size: "xl" %>
-        </div>
-        <p class="text-primary font-medium mb-2"><%= t("recurring_transactions.empty.title") %></p>
-        <p class="text-secondary text-sm mb-4"><%= t("recurring_transactions.empty.description") %></p>
+  <header class="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+    <div>
+      <p class="text-sm font-semibold text-secondary">Recurring money control</p>
+      <h1 class="mt-2 text-4xl font-black leading-none text-primary lg:text-5xl"><%= view_config[:title] %></h1>
+      <p class="mt-3 max-w-3xl text-base text-secondary lg:text-lg"><%= view_config[:description] %></p>
+    </div>
+
+    <% if @recurring_view == "detected" %>
+      <div class="flex flex-wrap items-center gap-2">
         <%= render DS::Link.new(
           text: t("recurring_transactions.identify_patterns"),
           icon: "search",
@@ -51,97 +41,165 @@
           href: identify_recurring_transactions_path,
           method: :post
         ) %>
+        <%= render DS::Menu.new do |menu| %>
+          <% menu.with_item(
+            variant: "button",
+            text: t("recurring_transactions.cleanup_stale"),
+            href: cleanup_recurring_transactions_path,
+            method: :post,
+            icon: "trash-2"
+          ) %>
+        <% end %>
+      </div>
+    <% end %>
+  </header>
+
+  <% if @recurring_view == "detected" %>
+    <div class="mb-6 rounded-[24px] border border-secondary bg-container-inset p-5">
+      <div class="flex items-start gap-3">
+        <%= icon "info", class: "mt-0.5 h-5 w-5 shrink-0 text-link" %>
+        <div>
+          <p class="text-sm font-semibold text-primary"><%= t("recurring_transactions.info.title") %></p>
+          <p class="mt-2 text-sm text-secondary"><%= t("recurring_transactions.info.manual_description") %></p>
+          <p class="mt-1 text-sm text-secondary"><%= t("recurring_transactions.info.automatic_description") %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <section class="overflow-hidden rounded-[24px] bg-container shadow-border-xs">
+    <div class="flex items-center justify-between border-b border-primary px-6 py-5">
+      <div>
+        <h2 class="text-xl font-semibold text-primary"><%= view_config[:title] %></h2>
+        <p class="mt-1 text-sm text-secondary"><%= @pagy.count %> entries</p>
+      </div>
+      <%= icon view_config[:icon], class: "h-5 w-5 text-secondary" %>
+    </div>
+
+    <% if @recurring_transactions.empty? %>
+      <div class="px-6 py-16 text-center">
+        <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-container-inset text-secondary">
+          <%= icon view_config[:icon], class: "h-7 w-7" %>
+        </div>
+        <h3 class="mt-4 text-lg font-semibold text-primary"><%= view_config[:empty_title] %></h3>
+        <p class="mx-auto mt-2 max-w-md text-sm text-secondary"><%= view_config[:empty_description] %></p>
       </div>
     <% else %>
-      <div class="rounded-xl bg-container-inset space-y-1 p-1">
-        <div class="flex items-center gap-1.5 px-4 py-2 text-xs font-medium text-secondary uppercase">
-          <p><%= t("recurring_transactions.title") %></p>
-          <span class="text-subdued">&middot;</span>
-          <p><%= @recurring_transactions.count %></p>
-        </div>
-
-        <div class="bg-container rounded-lg shadow-border-xs overflow-x-auto">
-          <table class="w-full">
+      <div class="overflow-x-auto">
+        <table class="min-w-full">
           <thead>
-            <tr class="text-xs uppercase font-medium text-secondary border-b border-divider">
-              <th class="text-left py-3 px-2"><%= t("recurring_transactions.table.merchant") %></th>
-              <th class="text-left py-3 px-2"><%= t("recurring_transactions.table.amount") %></th>
-              <th class="text-left py-3 px-2"><%= t("recurring_transactions.table.expected_day") %></th>
-              <th class="text-left py-3 px-2"><%= t("recurring_transactions.table.next_date") %></th>
-              <th class="text-left py-3 px-2"><%= t("recurring_transactions.table.last_occurrence") %></th>
-              <th class="text-left py-3 px-2"><%= t("recurring_transactions.table.status") %></th>
-              <th class="text-right py-3 px-2"><%= t("recurring_transactions.table.actions") %></th>
+            <tr class="border-b border-primary bg-container-inset">
+              <th class="px-6 py-4 text-left text-xs font-semibold uppercase text-secondary">Pattern</th>
+              <th class="px-6 py-4 text-left text-xs font-semibold uppercase text-secondary">Amount</th>
+              <th class="px-6 py-4 text-left text-xs font-semibold uppercase text-secondary">Schedule</th>
+              <th class="px-6 py-4 text-left text-xs font-semibold uppercase text-secondary">Confidence</th>
+              <th class="px-6 py-4 text-right text-xs font-semibold uppercase text-secondary">Actions</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="divide-y divide-tertiary">
             <% @recurring_transactions.each do |recurring_transaction| %>
-              <tr class="border-b border-subdued hover:bg-surface-hover <%= "opacity-60" unless recurring_transaction.active? %>">
-                <td class="py-3 px-2 text-sm">
-                  <div class="flex items-center gap-2">
-                    <% if recurring_transaction.merchant.present? %>
-                      <% if recurring_transaction.merchant.logo_url.present? %>
-                        <%= image_tag recurring_transaction.merchant.logo_url,
-                            class: "w-6 h-6 rounded-full",
-                            loading: "lazy" %>
-                      <% else %>
-                        <%= render DS::FilledIcon.new(
-                          variant: :text,
-                          text: recurring_transaction.merchant.name,
-                          size: "sm",
-                          rounded: true
-                        ) %>
-                      <% end %>
-                      <span class="text-primary font-medium"><%= recurring_transaction.merchant.name %></span>
-                    <% else %>
-                      <%= render DS::FilledIcon.new(
-                        variant: :text,
-                        text: recurring_transaction.name,
-                        size: "sm",
-                        rounded: true
-                      ) %>
-                      <span class="text-primary font-medium"><%= recurring_transaction.name %></span>
-                    <% end %>
-                    <% if recurring_transaction.manual? %>
-                      <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-50 text-blue-700 border border-blue-100">
-                        MANUAL
-                      </span>
-                    <% end %>
+              <tr class="<%= "opacity-60" unless recurring_transaction.active? || recurring_transaction.ignored? %>">
+                <td class="px-6 py-4">
+                  <div class="flex items-center gap-3">
+                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-container-inset text-secondary">
+                      <%= icon recurring_transaction.transfer? ? "arrow-left-right" : "repeat", class: "h-5 w-5" %>
+                    </div>
+                    <div class="min-w-0">
+                      <p class="truncate font-medium text-primary"><%= recurring_transaction.merchant&.name || recurring_transaction.name %></p>
+                      <p class="mt-1 text-xs text-secondary">
+                        <% if recurring_transaction.transfer? %>
+                          <%= recurring_transaction.account&.name %> to <%= recurring_transaction.destination_account&.name %>
+                        <% else %>
+                          <%= recurring_transaction.account&.name || "Account not assigned" %>
+                        <% end %>
+                      </p>
+                    </div>
                   </div>
                 </td>
-                <td class="py-3 px-2 text-sm font-medium <%= recurring_transaction.amount.negative? ? "text-success" : "text-primary" %>">
-                  <%= format_money(-recurring_transaction.amount_money) %>
+                <td class="px-6 py-4">
+                  <p class="font-semibold text-primary"><%= format_money(-recurring_transaction.amount_money) %></p>
+                  <p class="mt-1 text-xs text-secondary"><%= recurring_transaction.currency %></p>
                 </td>
-                <td class="py-3 px-2 text-sm text-secondary">
-                  <%= t("recurring_transactions.day_of_month", day: recurring_transaction.expected_day_of_month) %>
+                <td class="px-6 py-4">
+                  <p class="text-sm font-medium text-primary">Day <%= recurring_transaction.expected_day_of_month %></p>
+                  <p class="mt-1 text-xs text-secondary">
+                    <%= recurring_transaction.next_expected_date ? "Next #{l(recurring_transaction.next_expected_date, format: :short)}" : "No next date" %>
+                  </p>
                 </td>
-                <td class="py-3 px-2 text-sm text-secondary">
-                  <%= l(recurring_transaction.next_expected_date, format: :short) %>
-                </td>
-                <td class="py-3 px-2 text-sm text-secondary">
-                  <%= l(recurring_transaction.last_occurrence_date, format: :short) %>
-                </td>
-                <td class="py-3 px-2 text-sm">
-                  <% if recurring_transaction.active? %>
-                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-50 text-success">
-                      <%= t("recurring_transactions.status.active") %>
+                <td class="px-6 py-4">
+                  <% assessment = @assessments.fetch(recurring_transaction) %>
+                  <div class="flex items-center gap-2">
+                    <span class="inline-flex items-center rounded-full bg-container-inset px-3 py-1 text-xs font-semibold text-primary shadow-border-xs">
+                      <%= assessment.score %>%
                     </span>
-                  <% else %>
-                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-inset text-primary">
-                      <%= t("recurring_transactions.status.inactive") %>
-                    </span>
-                  <% end %>
+                    <span class="text-xs text-secondary"><%= assessment.label %></span>
+                  </div>
+                  <p class="mt-1 text-xs text-secondary">
+                    <%= assessment.evidence[:matched_transactions] %> matches · <%= recurring_transaction.status.humanize %>
+                  </p>
                 </td>
-                <td class="py-3 px-2 text-sm text-right">
+                <td class="px-6 py-4 text-right">
                   <div class="flex items-center justify-end gap-2">
-                    <%= link_to toggle_status_recurring_transaction_path(recurring_transaction),
-                        data: { turbo_method: :post },
-                        class: "text-secondary hover:text-primary" do %>
-                      <%= icon recurring_transaction.active? ? "pause" : "play", size: "sm" %>
-                    <% end %>
-                    <%= link_to recurring_transaction_path(recurring_transaction),
-                        data: { turbo_method: :delete, turbo_confirm: t("recurring_transactions.confirm_delete") },
-                        class: "text-secondary hover:text-destructive" do %>
-                      <%= icon "trash-2", size: "sm" %>
+                    <% if recurring_transaction.ignored? %>
+                      <%= link_to restore_recurring_transaction_path(recurring_transaction),
+                          data: { turbo_method: :post },
+                          class: "inline-flex h-9 items-center gap-2 rounded-full bg-container-inset px-3 text-sm font-semibold text-primary shadow-border-xs hover:bg-surface-hover",
+                          title: "Restore pattern" do %>
+                        <%= icon "rotate-ccw", class: "h-4 w-4" %>
+                        Restore
+                      <% end %>
+                    <% else %>
+                      <% assessment = @assessments.fetch(recurring_transaction) %>
+                      <% unless assessment.reviewed? || recurring_transaction.transfer? %>
+                        <%= link_to confirm_recurring_transaction_path(recurring_transaction),
+                            data: { turbo_method: :post },
+                            class: "inline-flex h-9 items-center gap-2 rounded-full bg-primary px-3 text-sm font-semibold text-gray-900 hover:bg-primary-hover",
+                            title: "Confirm recurring pattern" do %>
+                          <%= icon "check", class: "h-4 w-4" %>
+                          Confirm
+                        <% end %>
+                      <% end %>
+                      <% if @recurring_view == "detected" && recurring_transaction.account_id.present? %>
+                        <details class="relative">
+                          <summary class="flex h-9 w-9 cursor-pointer list-none items-center justify-center rounded-full text-secondary hover:bg-surface-hover hover:text-primary" title="Classify as transfer">
+                            <%= icon "arrow-left-right", class: "h-4 w-4" %>
+                          </summary>
+                          <div class="absolute right-0 z-20 mt-2 w-64 rounded-[16px] bg-container p-3 text-left shadow-lg ring-1 ring-black/10">
+                            <%= form_with url: mark_transfer_recurring_transaction_path(recurring_transaction), method: :post, class: "space-y-3" do |form| %>
+                              <%= form.label :destination_account_id, "Destination account", class: "text-xs font-semibold text-secondary" %>
+                              <%= form.select :destination_account_id,
+                                  options_from_collection_for_select(
+                                    @transfer_destinations.reject { |account| account.id == recurring_transaction.account_id },
+                                    :id,
+                                    :name
+                                  ),
+                                  {},
+                                  class: "w-full rounded-lg border border-primary bg-container px-3 py-2 text-sm text-primary" %>
+                              <%= form.submit "Mark as transfer", class: "w-full rounded-full bg-primary px-3 py-2 text-sm font-semibold text-gray-900" %>
+                            <% end %>
+                          </div>
+                        </details>
+                      <% end %>
+                      <% if recurring_transaction.subscription_candidate? %>
+                        <%= link_to create_subscription_recurring_transaction_path(recurring_transaction),
+                            data: { turbo_method: :post },
+                            class: "flex h-9 w-9 items-center justify-center rounded-full text-secondary hover:bg-surface-hover hover:text-primary",
+                            title: "Create subscription" do %>
+                          <%= icon "layers", class: "h-4 w-4" %>
+                        <% end %>
+                      <% end %>
+                      <%= link_to toggle_status_recurring_transaction_path(recurring_transaction, kind: @recurring_view),
+                          data: { turbo_method: :post },
+                          class: "flex h-9 w-9 items-center justify-center rounded-full text-secondary hover:bg-surface-hover hover:text-primary",
+                          title: recurring_transaction.active? ? "Pause pattern" : "Resume pattern" do %>
+                        <%= icon recurring_transaction.active? ? "pause" : "play", class: "h-4 w-4" %>
+                      <% end %>
+                      <%= link_to recurring_transaction_path(recurring_transaction, kind: @recurring_view),
+                          data: { turbo_method: :delete, turbo_confirm: t("recurring_transactions.confirm_delete") },
+                          class: "flex h-9 w-9 items-center justify-center rounded-full text-secondary hover:bg-surface-hover hover:text-destructive",
+                          title: "Ignore pattern" do %>
+                        <%= icon "eye-off", class: "h-4 w-4" %>
+                      <% end %>
                     <% end %>
                   </div>
                 </td>
@@ -149,8 +207,12 @@
             <% end %>
           </tbody>
         </table>
-        </div>
       </div>
+      <% if @pagy.pages > 1 %>
+        <div class="border-t border-primary px-6 py-4">
+          <%= render "shared/pagination", pagy: @pagy %>
+        </div>
+      <% end %>
     <% end %>
-  </div>
+  </section>
 </div>

--- a/app/views/subscription_mailer/recurring_anomaly.html.erb
+++ b/app/views/subscription_mailer/recurring_anomaly.html.erb
@@ -1,0 +1,8 @@
+<h1>Recurring payment needs attention</h1>
+
+<p><strong><%= @commitment.name %></strong> has a new recurring-payment alert.</p>
+
+<p><strong><%= @event_data["title"] %></strong></p>
+<p><%= @event_data["detail"] %></p>
+
+<p>Open Sure to review the expected date, amount, and matching transaction before taking action.</p>

--- a/app/views/subscription_plans/index.html.erb
+++ b/app/views/subscription_plans/index.html.erb
@@ -1,4 +1,6 @@
 <div class="mx-auto max-w-[1240px] px-4 py-6 lg:px-8">
+  <%= render "recurring/navigation", current: "subscriptions" %>
+
   <section class="mb-8 rounded-[24px] bg-surface p-6 theme-dark:bg-container lg:p-8">
     <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
       <div class="max-w-3xl">

--- a/app/views/transfers/show.html.erb
+++ b/app/views/transfers/show.html.erb
@@ -87,6 +87,28 @@
       <div class="pb-4">
         <div class="flex items-center justify-between gap-2 p-3">
           <div class="text-sm space-y-1">
+            <h4 class="text-primary">Recurring transfer</h4>
+            <p class="text-secondary">Track this account-to-account movement as a recurring cash flow.</p>
+          </div>
+
+          <% if @recurring_transfer_exists %>
+            <span class="inline-flex items-center gap-2 text-sm font-medium text-secondary">
+              <%= icon "check", size: "sm" %>
+              Already recurring
+            </span>
+          <% else %>
+            <%= render DS::Button.new(
+              text: "Mark recurring",
+              variant: "outline",
+              icon: "repeat",
+              href: mark_as_recurring_transfer_path(@transfer),
+              method: :post,
+              frame: "_top"
+            ) %>
+          <% end %>
+        </div>
+        <div class="flex items-center justify-between gap-2 p-3">
+          <div class="text-sm space-y-1">
             <h4 class="text-primary"><%= t(".delete_title") %></h4>
             <p class="text-secondary"><%= t(".delete_subtitle") %></p>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
   resource :registration, only: %i[new create]
 
   # Subscription Manager routes
+  get "/recurring", to: "recurring#index", as: :recurring
+
   resources :subscription_plans do
     collection do
       get :check_duplicate
@@ -160,7 +162,9 @@ Rails.application.routes.draw do
 
   resources :family_merchants, only: %i[index new create edit update destroy]
 
-  resources :transfers, only: %i[new create destroy show update]
+  resources :transfers, only: %i[new create destroy show update] do
+    post :mark_as_recurring, on: :member
+  end
 
   resources :imports, only: %i[index new show create destroy] do
     member do
@@ -216,6 +220,10 @@ Rails.application.routes.draw do
 
     member do
       post :toggle_status
+      post :create_subscription
+      post :restore
+      post :confirm
+      post :mark_transfer
     end
   end
 

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -19,6 +19,12 @@ subscription_renewals:
   queue: "scheduled"
   description: "Processes subscription lifecycle changes and sends renewal reminders"
 
+recurring_intelligence:
+  cron: "30 7 * * *"
+  class: "RecurringIntelligenceJob"
+  queue: "scheduled"
+  description: "Identifies and reconciles recurring cash-flow patterns"
+
 clean_syncs:
   cron: "0 * * * *" # every hour
   class: "SyncCleanerJob"

--- a/db/migrate/20260606000100_add_account_scope_and_suppressions_to_recurring_transactions.rb
+++ b/db/migrate/20260606000100_add_account_scope_and_suppressions_to_recurring_transactions.rb
@@ -1,0 +1,140 @@
+class AddAccountScopeAndSuppressionsToRecurringTransactions < ActiveRecord::Migration[8.1]
+  def up
+    add_account_scope_to_recurring_transactions
+    create_recurring_transaction_suppressions
+  end
+
+  def down
+    drop_table :recurring_transaction_suppressions, if_exists: true
+
+    remove_index :recurring_transactions, name: "idx_recurring_txns_acct_merchant", if_exists: true
+    remove_index :recurring_transactions, name: "idx_recurring_txns_acct_name", if_exists: true
+
+    add_index :recurring_transactions,
+      [ :family_id, :merchant_id, :amount, :currency ],
+      unique: true,
+      name: "idx_recurring_txns_on_family_merchant_amount_currency",
+      if_not_exists: true
+
+    remove_reference :recurring_transactions, :account, foreign_key: true, if_exists: true
+  end
+
+  private
+
+    def add_account_scope_to_recurring_transactions
+      unless column_exists?(:recurring_transactions, :account_id)
+        add_reference :recurring_transactions,
+          :account,
+          type: :uuid,
+          null: true,
+          foreign_key: { to_table: :accounts, on_delete: :cascade }
+      end
+
+      backfill_recurring_transaction_accounts
+
+      dedupe_recurring_transactions!(
+        partition_columns: %w[family_id account_id merchant_id amount currency],
+        where_clause: "account_id IS NOT NULL AND merchant_id IS NOT NULL"
+      )
+
+      dedupe_recurring_transactions!(
+        partition_columns: %w[family_id account_id name amount currency],
+        where_clause: "account_id IS NOT NULL AND merchant_id IS NULL AND name IS NOT NULL"
+      )
+
+      remove_index :recurring_transactions,
+        name: "idx_recurring_txns_on_family_merchant_amount_currency",
+        if_exists: true
+
+      add_index :recurring_transactions,
+        [ :family_id, :account_id, :merchant_id, :amount, :currency ],
+        unique: true,
+        where: "account_id IS NOT NULL AND merchant_id IS NOT NULL",
+        name: "idx_recurring_txns_acct_merchant",
+        if_not_exists: true
+
+      add_index :recurring_transactions,
+        [ :family_id, :account_id, :name, :amount, :currency ],
+        unique: true,
+        where: "account_id IS NOT NULL AND merchant_id IS NULL AND name IS NOT NULL",
+        name: "idx_recurring_txns_acct_name",
+        if_not_exists: true
+    end
+
+    def backfill_recurring_transaction_accounts
+      execute <<~SQL
+        UPDATE recurring_transactions rt
+        SET account_id = matches.account_id
+        FROM (
+          SELECT DISTINCT ON (rt2.id)
+            rt2.id AS recurring_transaction_id,
+            entries.account_id
+          FROM recurring_transactions rt2
+          JOIN entries
+            ON entries.entryable_type = 'Transaction'
+           AND entries.currency = rt2.currency
+           AND entries.amount = rt2.amount
+           AND EXTRACT(DAY FROM entries.date)
+             BETWEEN GREATEST(rt2.expected_day_of_month - 2, 1)
+                 AND LEAST(rt2.expected_day_of_month + 2, 31)
+          JOIN accounts
+            ON accounts.id = entries.account_id
+           AND accounts.family_id = rt2.family_id
+          LEFT JOIN transactions
+            ON transactions.id = entries.entryable_id
+          WHERE rt2.account_id IS NULL
+            AND (
+              (rt2.merchant_id IS NOT NULL AND transactions.merchant_id = rt2.merchant_id)
+              OR (rt2.merchant_id IS NULL AND entries.name = rt2.name)
+            )
+          ORDER BY rt2.id, entries.date DESC
+        ) matches
+        WHERE rt.id = matches.recurring_transaction_id
+      SQL
+    end
+
+    def create_recurring_transaction_suppressions
+      return if table_exists?(:recurring_transaction_suppressions)
+
+      create_table :recurring_transaction_suppressions, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+        t.references :family, null: false, foreign_key: { on_delete: :cascade }, type: :uuid
+        t.references :account, foreign_key: { on_delete: :cascade }, type: :uuid
+        t.references :merchant, foreign_key: { on_delete: :nullify }, type: :uuid
+        t.string :name
+        t.decimal :amount, precision: 19, scale: 4, null: false
+        t.string :currency, null: false
+        t.integer :expected_day_of_month
+        t.string :signature, null: false
+        t.string :reason, null: false, default: "user_ignored"
+        t.jsonb :metadata, default: {}, null: false
+        t.timestamps
+      end
+
+      add_index :recurring_transaction_suppressions,
+        [ :family_id, :signature ],
+        unique: true,
+        name: "idx_recurring_txn_suppressions_unique"
+    end
+
+    def dedupe_recurring_transactions!(partition_columns:, where_clause:)
+      execute <<~SQL
+        WITH ranked AS (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY #{partition_columns.join(', ')}
+                   ORDER BY manual DESC,
+                            (status = 'active') DESC,
+                            last_occurrence_date DESC NULLS LAST,
+                            updated_at DESC,
+                            id DESC
+                 ) AS row_num
+          FROM recurring_transactions
+          WHERE #{where_clause}
+        )
+        DELETE FROM recurring_transactions
+        WHERE id IN (
+          SELECT id FROM ranked WHERE row_num > 1
+        )
+      SQL
+    end
+end

--- a/db/migrate/20260606000300_harden_recurring_identity_and_transfers.rb
+++ b/db/migrate/20260606000300_harden_recurring_identity_and_transfers.rb
@@ -1,0 +1,156 @@
+require "digest"
+
+class HardenRecurringIdentityAndTransfers < ActiveRecord::Migration[8.1]
+  class MigrationRecurringTransaction < ActiveRecord::Base
+    self.table_name = "recurring_transactions"
+  end
+
+  class MigrationRecurringSuppression < ActiveRecord::Base
+    self.table_name = "recurring_transaction_suppressions"
+  end
+
+  def up
+    add_recurring_transfer_and_identity
+  end
+
+  def down
+    remove_check_constraint :recurring_transactions, name: "chk_recurring_txns_transfer_requires_source", if_exists: true
+    remove_check_constraint :recurring_transactions, name: "chk_recurring_txns_transfer_distinct_accounts", if_exists: true
+    remove_index :recurring_transactions, name: "idx_recurring_txns_identity", if_exists: true
+    execute "DELETE FROM recurring_transactions WHERE destination_account_id IS NOT NULL"
+    add_index :recurring_transactions,
+      [ :family_id, :account_id, :merchant_id, :amount, :currency ],
+      unique: true,
+      where: "account_id IS NOT NULL AND merchant_id IS NOT NULL",
+      name: "idx_recurring_txns_acct_merchant",
+      if_not_exists: true
+    add_index :recurring_transactions,
+      [ :family_id, :account_id, :name, :amount, :currency ],
+      unique: true,
+      where: "account_id IS NOT NULL AND merchant_id IS NULL AND name IS NOT NULL",
+      name: "idx_recurring_txns_acct_name",
+      if_not_exists: true
+    remove_column :recurring_transactions, :identity_signature, if_exists: true
+    remove_reference :recurring_transactions, :destination_account, foreign_key: { to_table: :accounts }, if_exists: true
+
+    MigrationRecurringSuppression.reset_column_information
+    MigrationRecurringSuppression.find_each do |suppression|
+      suppression.update_columns(signature: legacy_suppression_signature_for(suppression))
+    end
+
+    remove_reference :recurring_transaction_suppressions, :destination_account, foreign_key: { to_table: :accounts }, if_exists: true
+  end
+
+  private
+    def add_recurring_transfer_and_identity
+      unless column_exists?(:recurring_transactions, :destination_account_id)
+        add_reference :recurring_transactions,
+          :destination_account,
+          type: :uuid,
+          null: true,
+          foreign_key: { to_table: :accounts, on_delete: :cascade }
+      end
+
+      unless column_exists?(:recurring_transaction_suppressions, :destination_account_id)
+        add_reference :recurring_transaction_suppressions,
+          :destination_account,
+          type: :uuid,
+          null: true,
+          foreign_key: { to_table: :accounts, on_delete: :cascade }
+      end
+
+      MigrationRecurringSuppression.reset_column_information
+      MigrationRecurringSuppression.find_each do |suppression|
+        suppression.update_columns(signature: suppression_signature_for(suppression))
+      end
+
+      add_column :recurring_transactions, :identity_signature, :string unless column_exists?(:recurring_transactions, :identity_signature)
+
+      MigrationRecurringTransaction.reset_column_information
+      MigrationRecurringTransaction.find_each do |recurring|
+        recurring.update_columns(identity_signature: recurring_identity_for(recurring))
+      end
+
+      deduplicate_recurring_identities
+
+      change_column_null :recurring_transactions, :identity_signature, false
+      remove_index :recurring_transactions, name: "idx_recurring_txns_acct_merchant", if_exists: true
+      remove_index :recurring_transactions, name: "idx_recurring_txns_acct_name", if_exists: true
+      add_index :recurring_transactions,
+        [ :family_id, :identity_signature ],
+        unique: true,
+        name: "idx_recurring_txns_identity",
+        if_not_exists: true
+
+      add_check_constraint :recurring_transactions,
+        "destination_account_id IS NULL OR account_id IS NOT NULL",
+        name: "chk_recurring_txns_transfer_requires_source",
+        if_not_exists: true
+
+      add_check_constraint :recurring_transactions,
+        "destination_account_id IS NULL OR destination_account_id <> account_id",
+        name: "chk_recurring_txns_transfer_distinct_accounts",
+        if_not_exists: true
+    end
+
+    def recurring_identity_for(recurring)
+      normalized_name = recurring.name.to_s.squish.downcase
+      normalized_amount = BigDecimal(recurring.amount.to_s).round(2).to_s("F")
+      raw_identity = [
+        "source:#{recurring.account_id || 'any'}",
+        "destination:#{recurring.destination_account_id || 'none'}",
+        "merchant:#{recurring.merchant_id || 'none'}",
+        "name:#{normalized_name}",
+        "amount:#{normalized_amount}",
+        "currency:#{recurring.currency.to_s.upcase}"
+      ].join("|")
+
+      Digest::SHA256.hexdigest(raw_identity)
+    end
+
+    def suppression_signature_for(suppression)
+      normalized_name = suppression.name.to_s.squish.downcase
+      normalized_amount = BigDecimal(suppression.amount.to_s).round(2).to_s("F")
+
+      [
+        "account:#{suppression.account_id || 'any'}",
+        "destination:#{suppression.destination_account_id || 'none'}",
+        "merchant:#{suppression.merchant_id || 'none'}",
+        "name:#{normalized_name}",
+        "amount:#{normalized_amount}",
+        "currency:#{suppression.currency}"
+      ].join("|")
+    end
+
+    def legacy_suppression_signature_for(suppression)
+      normalized_name = suppression.name.to_s.squish.downcase
+      normalized_amount = BigDecimal(suppression.amount.to_s).round(2).to_s("F")
+
+      [
+        "account:#{suppression.account_id || 'any'}",
+        "merchant:#{suppression.merchant_id || 'none'}",
+        "name:#{normalized_name}",
+        "amount:#{normalized_amount}",
+        "currency:#{suppression.currency}"
+      ].join("|")
+    end
+
+    def deduplicate_recurring_identities
+      execute <<~SQL
+        WITH ranked AS (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY family_id, identity_signature
+                   ORDER BY manual DESC,
+                            (status = 'active') DESC,
+                            last_occurrence_date DESC NULLS LAST,
+                            updated_at DESC,
+                            id DESC
+                 ) AS row_num
+          FROM recurring_transactions
+        )
+        DELETE FROM recurring_transactions
+        WHERE id IN (SELECT id FROM ranked WHERE row_num > 1)
+      SQL
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1020,15 +1020,39 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_06_000500) do
     t.index ["user_id"], name: "index_provider_directories_on_user_id"
   end
 
-  create_table "recurring_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "recurring_transaction_suppressions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id"
     t.decimal "amount", precision: 19, scale: 4, null: false
     t.datetime "created_at", null: false
     t.string "currency", null: false
+    t.uuid "destination_account_id"
+    t.integer "expected_day_of_month"
+    t.uuid "family_id", null: false
+    t.uuid "merchant_id"
+    t.jsonb "metadata", default: {}, null: false
+    t.string "name"
+    t.string "reason", default: "user_ignored", null: false
+    t.string "signature", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_recurring_transaction_suppressions_on_account_id"
+    t.index ["destination_account_id"], name: "idx_on_destination_account_id_748a37a110"
+    t.index ["family_id", "signature"], name: "idx_recurring_txn_suppressions_unique", unique: true
+    t.index ["family_id"], name: "index_recurring_transaction_suppressions_on_family_id"
+    t.index ["merchant_id"], name: "index_recurring_transaction_suppressions_on_merchant_id"
+  end
+
+  create_table "recurring_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "account_id"
+    t.decimal "amount", precision: 19, scale: 4, null: false
+    t.datetime "created_at", null: false
+    t.string "currency", null: false
+    t.uuid "destination_account_id"
     t.decimal "expected_amount_avg", precision: 19, scale: 4
     t.decimal "expected_amount_max", precision: 19, scale: 4
     t.decimal "expected_amount_min", precision: 19, scale: 4
     t.integer "expected_day_of_month", null: false
     t.uuid "family_id", null: false
+    t.string "identity_signature", null: false
     t.date "last_occurrence_date", null: false
     t.boolean "manual", default: false
     t.uuid "merchant_id"
@@ -1037,11 +1061,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_06_000500) do
     t.integer "occurrence_count", default: 0, null: false
     t.string "status", default: "active", null: false
     t.datetime "updated_at", null: false
-    t.index ["family_id", "merchant_id", "amount", "currency"], name: "idx_recurring_txns_on_family_merchant_amount_currency", unique: true
+    t.index ["account_id"], name: "index_recurring_transactions_on_account_id"
+    t.index ["destination_account_id"], name: "index_recurring_transactions_on_destination_account_id"
+    t.index ["family_id", "identity_signature"], name: "idx_recurring_txns_identity", unique: true
     t.index ["family_id", "status"], name: "index_recurring_transactions_on_family_id_and_status"
     t.index ["family_id"], name: "index_recurring_transactions_on_family_id"
     t.index ["merchant_id"], name: "index_recurring_transactions_on_merchant_id"
     t.index ["next_expected_date"], name: "index_recurring_transactions_on_next_expected_date"
+    t.check_constraint "destination_account_id IS NULL OR account_id IS NOT NULL", name: "chk_recurring_txns_transfer_requires_source"
+    t.check_constraint "destination_account_id IS NULL OR destination_account_id <> account_id", name: "chk_recurring_txns_transfer_distinct_accounts"
   end
 
   create_table "rejected_transfers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1539,6 +1567,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_06_000500) do
   add_foreign_key "plaid_items", "families"
   add_foreign_key "precious_metals", "accounts", column: "preferred_funding_account_id", on_delete: :nullify
   add_foreign_key "provider_directories", "users"
+  add_foreign_key "recurring_transaction_suppressions", "accounts", column: "destination_account_id", on_delete: :cascade
+  add_foreign_key "recurring_transaction_suppressions", "accounts", on_delete: :cascade
+  add_foreign_key "recurring_transaction_suppressions", "families", on_delete: :cascade
+  add_foreign_key "recurring_transaction_suppressions", "merchants", on_delete: :nullify
+  add_foreign_key "recurring_transactions", "accounts", column: "destination_account_id", on_delete: :cascade
+  add_foreign_key "recurring_transactions", "accounts", on_delete: :cascade
   add_foreign_key "recurring_transactions", "families"
   add_foreign_key "recurring_transactions", "merchants"
   add_foreign_key "rejected_transfers", "transactions", column: "inflow_transaction_id"

--- a/test/controllers/recurring_controller_test.rb
+++ b/test/controllers/recurring_controller_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class RecurringControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+  end
+
+  test "shows the recurring workspace overview" do
+    get recurring_url
+
+    assert_response :success
+    assert_select "h1", text: "Recurring"
+    assert_select "a[href='#{subscription_plans_path}']", text: /Subscriptions/
+    assert_select "a[href='#{recurring_transactions_path}']", text: /Detected/
+    assert_select "a[href='#{recurring_transactions_path(kind: "transfers")}']", text: /Transfers/
+    assert_select "a[href='#{recurring_transactions_path(kind: "ignored")}']", text: /Ignored/
+  end
+
+  test "attention feed identifies the commitment and reconciliation context" do
+    subscription = subscription_plans(:netflix_subscription)
+    Recurring::EventRecorder.record!(
+      record: subscription,
+      event: "recurring.amount_changed",
+      key: "overview-context-test",
+      title: "Amount changed",
+      detail: "Expected 22.99, observed 27.99.",
+      severity: "warning",
+      metadata: {
+        expected_date: Date.current,
+        expected_amount: 22.99,
+        observed_amount: 27.99,
+        entry_count: 1
+      }
+    )
+
+    get recurring_url
+
+    assert_response :success
+    assert_select "[data-recurring-event]", text: /Amount changed.*Netflix Premium/m
+    assert_select "[data-recurring-event]", text: /Expected.*USD 22\.99/m
+    assert_select "[data-recurring-event]", text: /Observed.*USD 27\.99/m
+  end
+end

--- a/test/controllers/recurring_transactions_controller_test.rb
+++ b/test/controllers/recurring_transactions_controller_test.rb
@@ -1,0 +1,183 @@
+require "test_helper"
+
+class RecurringTransactionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in users(:family_admin)
+    @family = families(:dylan_family)
+    @family.recurring_transactions.destroy_all
+    RecurringTransactionSuppression.where(family: @family).delete_all
+  end
+
+  test "index hides ignored recurring transactions" do
+    visible = @family.recurring_transactions.create!(
+      name: "Visible Gym",
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 5.days.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    ignored = @family.recurring_transactions.create!(
+      name: "Ignored Gym",
+      amount: 55.99,
+      currency: "USD",
+      expected_day_of_month: 10,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 10.days.from_now.to_date,
+      status: "ignored",
+      occurrence_count: 3
+    )
+
+    get recurring_transactions_url
+
+    assert_response :success
+    assert_includes response.body, visible.name
+    assert_not_includes response.body, ignored.name
+  end
+
+  test "index separates detected transactions from recurring transfers" do
+    detected = @family.recurring_transactions.create!(
+      name: "Detected Membership",
+      account: accounts(:depository),
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 5.days.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+    transfer = @family.recurring_transactions.create!(
+      name: "Monthly Investment",
+      account: accounts(:depository),
+      destination_account: accounts(:investment),
+      amount: 100,
+      currency: "USD",
+      expected_day_of_month: 10,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 10.days.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    get recurring_transactions_url
+    assert_includes response.body, detected.name
+    assert_not_includes response.body, transfer.name
+
+    get recurring_transactions_url(kind: "transfers")
+    assert_not_includes response.body, detected.name
+    assert_includes response.body, transfer.name
+  end
+
+  test "ignored view restores recurring transaction and removes suppression" do
+    recurring = @family.recurring_transactions.create!(
+      merchant: merchants(:amazon),
+      account: accounts(:depository),
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 5.days.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+    recurring.ignore!
+
+    get recurring_transactions_url(kind: "ignored")
+    assert_response :success
+    assert_includes response.body, recurring.merchant.name
+
+    assert_difference "RecurringTransactionSuppression.count", -1 do
+      post restore_recurring_transaction_url(recurring)
+    end
+
+    assert_redirected_to recurring_transactions_url(kind: "ignored")
+    assert recurring.reload.active?
+  end
+
+  test "confirm marks the pattern as reviewed" do
+    recurring = @family.recurring_transactions.create!(
+      name: "Confirmed Membership",
+      account: accounts(:depository),
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 5.days.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    post confirm_recurring_transaction_url(recurring)
+
+    assert_redirected_to recurring_transactions_url
+    assert recurring.reload.manual?
+    assert recurring.audit_logs.where(event: "recurring.confirmed").exists?
+  end
+
+  test "mark transfer validates and assigns a family destination account" do
+    recurring = @family.recurring_transactions.create!(
+      name: "Monthly Savings",
+      account: accounts(:depository),
+      amount: 200,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 5.days.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    post mark_transfer_recurring_transaction_url(recurring),
+      params: { destination_account_id: accounts(:investment).id }
+
+    assert_redirected_to recurring_transactions_url(kind: "transfers")
+    assert_equal accounts(:investment), recurring.reload.destination_account
+    assert recurring.audit_logs.where(event: "recurring.classified_transfer").exists?
+  end
+
+  test "destroy suppresses recurring transaction without deleting it" do
+    recurring = @family.recurring_transactions.create!(
+      merchant: merchants(:amazon),
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 5.days.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    assert_no_difference "RecurringTransaction.count" do
+      delete recurring_transaction_url(recurring)
+    end
+
+    assert_redirected_to recurring_transactions_url
+    assert_equal "ignored", recurring.reload.status
+  end
+
+  test "create_subscription promotes recurring transaction to subscription plan" do
+    recurring = @family.recurring_transactions.create!(
+      merchant: merchants(:amazon),
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: 5.days.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    assert_difference "SubscriptionPlan.count", 1 do
+      post create_subscription_recurring_transaction_url(recurring)
+    end
+
+    subscription_plan = SubscriptionPlan.order(:created_at).last
+    assert_redirected_to subscription_plan_url(subscription_plan)
+    assert_equal "ignored", recurring.reload.status
+    assert_equal recurring.id, subscription_plan.metadata.dig("source", "id")
+  end
+end

--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -85,4 +85,40 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
       transfer.reload
     end
   end
+
+  test "marks a transfer as recurring" do
+    transfer = transfers(:one)
+
+    assert_difference "RecurringTransaction.count", 1 do
+      post mark_as_recurring_transfer_url(transfer)
+    end
+
+    recurring = RecurringTransaction.order(:created_at).last
+    assert_redirected_to recurring_transactions_path
+    assert_equal transfer.from_account, recurring.account
+    assert_equal transfer.to_account, recurring.destination_account
+  end
+
+  test "show exposes recurring transfer action" do
+    transfer = transfers(:one)
+
+    get transfer_url(transfer)
+
+    assert_response :success
+    assert_select "form[action='#{mark_as_recurring_transfer_path(transfer)}']" do
+      assert_select "button", text: /Mark recurring/
+    end
+  end
+
+  test "does not create the same recurring transfer twice" do
+    transfer = transfers(:one)
+    RecurringTransaction.create_from_transfer(transfer)
+
+    assert_no_difference "RecurringTransaction.count" do
+      post mark_as_recurring_transfer_url(transfer)
+    end
+
+    assert_redirected_to transactions_path
+    assert_equal "This recurring transfer already exists or is invalid.", flash[:alert]
+  end
 end

--- a/test/fixtures/recurring_transactions.yml
+++ b/test/fixtures/recurring_transactions.yml
@@ -1,5 +1,6 @@
 netflix_subscription:
   family: dylan_family
+  account: depository
   merchant: netflix
   amount: 15.99
   currency: USD
@@ -8,9 +9,11 @@ netflix_subscription:
   next_expected_date: <%= 5.days.from_now.to_date %>
   status: active
   occurrence_count: 3
+  identity_signature: fixture-netflix-subscription
 
 inactive_subscription:
   family: dylan_family
+  account: credit_card
   merchant: amazon
   amount: 9.99
   currency: USD
@@ -19,3 +22,4 @@ inactive_subscription:
   next_expected_date: <%= 2.months.ago.to_date %>
   status: inactive
   occurrence_count: 2
+  identity_signature: fixture-inactive-subscription

--- a/test/jobs/identify_recurring_transactions_job_test.rb
+++ b/test/jobs/identify_recurring_transactions_job_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class IdentifyRecurringTransactionsJobTest < ActiveJob::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @scheduled_at = Time.current.to_f
+    Sync.for_family(@family).incomplete.destroy_all
+  end
+
+  test "schedule_for records the latest request and enqueues a delayed job" do
+    Rails.cache.expects(:write).with(
+      IdentifyRecurringTransactionsJob.cache_key(@family.id),
+      instance_of(Float),
+      expires_in: IdentifyRecurringTransactionsJob::CACHE_TTL
+    )
+
+    assert_enqueued_with(job: IdentifyRecurringTransactionsJob) do
+      IdentifyRecurringTransactionsJob.schedule_for(@family)
+    end
+  end
+
+  test "runs identification when no family sync is incomplete" do
+    Rails.cache.stubs(:read).returns(nil)
+    RecurringTransaction.expects(:identify_patterns_for).with(@family).once
+
+    IdentifyRecurringTransactionsJob.perform_now(@family.id, @scheduled_at)
+  end
+
+  test "skips identification while a family sync is incomplete" do
+    Sync.create!(syncable: @family, status: "pending")
+    Rails.cache.stubs(:read).returns(nil)
+    RecurringTransaction.expects(:identify_patterns_for).never
+
+    IdentifyRecurringTransactionsJob.perform_now(@family.id, @scheduled_at)
+  end
+
+  test "skips a job superseded by a newer schedule" do
+    Rails.cache.stubs(:read).with(
+      IdentifyRecurringTransactionsJob.cache_key(@family.id)
+    ).returns(@scheduled_at + 1)
+    RecurringTransaction.expects(:identify_patterns_for).never
+
+    IdentifyRecurringTransactionsJob.perform_now(@family.id, @scheduled_at)
+  end
+
+  test "skips identification when the family no longer exists" do
+    RecurringTransaction.expects(:identify_patterns_for).never
+
+    IdentifyRecurringTransactionsJob.perform_now(SecureRandom.uuid, @scheduled_at)
+  end
+end

--- a/test/jobs/reconcile_transaction_job_test.rb
+++ b/test/jobs/reconcile_transaction_job_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class ReconcileTransactionJobTest < ActiveJob::TestCase
+  test "runs scoped reconciliation for a transaction entry" do
+    entry = entries(:transaction)
+    reconciler = mock
+    notifier = mock
+
+    Recurring::Reconciler.expects(:new).with(
+      entry.account.family,
+      as_of: entry.date,
+      entry: entry
+    ).returns(reconciler)
+    reconciler.expects(:reconcile!).once.returns([ mock ])
+    Recurring::Notifier.expects(:new).with(
+      entry.account.family,
+      as_of: entry.date
+    ).returns(notifier)
+    notifier.expects(:deliver!).once
+
+    ReconcileTransactionJob.perform_now(entry.id)
+  end
+
+  test "skips entries already linked to a subscription renewal" do
+    entry = entries(:transaction)
+    SubscriptionRenewal.expects(:where).with(entry_id: entry.id).returns(stub(exists?: true))
+    Recurring::Reconciler.expects(:new).never
+
+    ReconcileTransactionJob.perform_now(entry.id)
+  end
+end

--- a/test/jobs/recurring_intelligence_job_test.rb
+++ b/test/jobs/recurring_intelligence_job_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class RecurringIntelligenceJobTest < ActiveJob::TestCase
+  test "reconciles and notifies every family" do
+    Family.all.each do |family|
+      reconciler = mock
+      notifier = mock
+
+      Recurring::Reconciler.expects(:new).with(family, as_of: Date.current).returns(reconciler)
+      reconciler.expects(:reconcile!).once
+      Recurring::Notifier.expects(:new).with(family, as_of: Date.current).returns(notifier)
+      notifier.expects(:deliver!).once
+    end
+
+    RecurringIntelligenceJob.perform_now(Date.current)
+  end
+end

--- a/test/mailers/subscription_mailer_test.rb
+++ b/test/mailers/subscription_mailer_test.rb
@@ -1,6 +1,25 @@
 require "test_helper"
 
 class SubscriptionMailerTest < ActionMailer::TestCase
+  test "recurring anomaly targets the family primary user" do
+    family = families(:dylan_family)
+    subscription = subscription_plans(:netflix_subscription)
+    event = Recurring::EventRecorder.record!(
+      record: subscription,
+      event: "recurring.missed",
+      key: "mailer-test",
+      title: "Missed payment",
+      detail: "No matching payment was found.",
+      severity: "warning"
+    )
+
+    mail = SubscriptionMailer.recurring_anomaly(family, subscription, event)
+
+    assert_equal [ family.primary_user.email ], mail.to
+    assert_match subscription.name, mail.subject
+    assert_match "No matching payment was found.", mail.body.encoded
+  end
+
   test "trial ending renders the milestone and subscription link" do
     subscription = subscription_plans(:netflix_subscription)
     subscription.update!(status: "trial", trial_ends_at: 2.days.from_now.to_date)

--- a/test/models/budget_test.rb
+++ b/test/models/budget_test.rb
@@ -10,6 +10,16 @@ class BudgetTest < ActiveSupport::TestCase
     assert Budget.budget_date_valid?(two_years_ago, family: @family)
   end
 
+  test "projected available spending includes future recurring commitments" do
+    budget = budgets(:one)
+
+    assert_operator budget.projected_recurring_spending, :>=, 0
+    assert_equal(
+      budget.available_to_spend - budget.projected_recurring_spending,
+      budget.projected_available_to_spend
+    )
+  end
+
   test "budget_date_valid? allows going back to earliest entry date if more than 2 years ago" do
     # Create an entry 3 years ago
     old_account = Account.create!(

--- a/test/models/recurring/assessment_test.rb
+++ b/test/models/recurring/assessment_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class Recurring::AssessmentTest < ActiveSupport::TestCase
+  test "scores recurring evidence and exposes a label" do
+    recurring_transaction = recurring_transactions(:netflix_subscription)
+    assessment = Recurring::Assessment.new(recurring_transaction)
+
+    assert_includes 0..100, assessment.score
+    assert_includes %w[Low Medium High], assessment.label
+    assert_equal recurring_transaction.occurrence_count, assessment.evidence[:occurrence_count]
+    assert assessment.evidence.key?(:matched_transactions)
+  end
+
+  test "reports whether a pattern was explicitly reviewed" do
+    recurring_transaction = recurring_transactions(:netflix_subscription)
+    assessment = Recurring::Assessment.new(recurring_transaction)
+
+    assert_not assessment.reviewed?
+
+    recurring_transaction.confirm_as_recurring!
+
+    assert Recurring::Assessment.new(recurring_transaction).reviewed?
+    assert_equal 1, recurring_transaction.audit_logs.where(event: "recurring.confirmed").count
+
+    recurring_transaction.confirm_as_recurring!
+
+    assert_equal 1, recurring_transaction.audit_logs.where(event: "recurring.confirmed").count
+  end
+end

--- a/test/models/recurring/forecast_test.rb
+++ b/test/models/recurring/forecast_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class Recurring::ForecastTest < ActiveSupport::TestCase
+  test "projects active commitments inside the requested horizon" do
+    family = families(:dylan_family)
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(next_billing_at: 5.days.from_now.to_date)
+
+    forecast = Recurring::Forecast.new(
+      family,
+      start_date: Date.current,
+      end_date: 10.days.from_now.to_date
+    )
+
+    item = forecast.items.find { |candidate| candidate.commitment == subscription }
+
+    assert item
+    assert_equal subscription.next_billing_at, item.date
+    assert_not item.actualized
+    assert_operator forecast.projected_outflow, :>=, subscription.amount
+  end
+
+  test "does not project a commitment that already has an actual transaction" do
+    family = families(:dylan_family)
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(next_billing_at: 5.days.from_now.to_date)
+    match_key = "SubscriptionPlan:#{subscription.id}:#{subscription.next_billing_at}"
+    transaction = Transaction.create!(
+      extra: {
+        "recurring_matches" => {
+          match_key => {
+            "commitment_id" => subscription.id,
+            "expected_date" => subscription.next_billing_at.to_s
+          }
+        }
+      }
+    )
+    accounts(:depository).entries.create!(
+      name: subscription.name,
+      amount: subscription.amount,
+      currency: subscription.currency,
+      date: subscription.next_billing_at,
+      entryable: transaction
+    )
+
+    forecast = Recurring::Forecast.new(
+      family,
+      start_date: Date.current,
+      end_date: 10.days.from_now.to_date
+    )
+    item = forecast.items.find { |candidate| candidate.commitment == subscription }
+
+    assert item.actualized
+    assert_not_includes forecast.projected_items, item
+  end
+end

--- a/test/models/recurring/notifier_test.rb
+++ b/test/models/recurring/notifier_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Recurring::NotifierTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  include ActionMailer::TestHelper
+
+  test "delivers an anomaly once" do
+    family = families(:dylan_family)
+    subscription = subscription_plans(:netflix_subscription)
+    event = Recurring::EventRecorder.record!(
+      record: subscription,
+      event: "recurring.amount_changed",
+      key: "amount-change-test",
+      title: "Amount changed",
+      detail: "Expected 10, observed 12.",
+      severity: "warning"
+    )
+
+    assert_enqueued_emails 1 do
+      assert_equal 1, Recurring::Notifier.new(family).deliver!
+    end
+
+    assert_equal 0, Recurring::Notifier.new(family).deliver!
+    assert subscription.audit_logs.where(event: "recurring.notification_sent")
+      .where("changeset -> 'metadata' ->> 'source_event_id' = ?", event.id.to_s)
+      .exists?
+  end
+end

--- a/test/models/recurring/reconciler_test.rb
+++ b/test/models/recurring/reconciler_test.rb
@@ -1,0 +1,180 @@
+require "test_helper"
+
+class Recurring::ReconcilerTest < ActiveSupport::TestCase
+  setup do
+    @family = families(:dylan_family)
+    @account = accounts(:depository)
+    @merchant = merchants(:amazon)
+  end
+
+  test "matches an actual transaction and remains idempotent" do
+    recurring_transaction = create_recurring_transaction(
+      name: "Reconciler Gym",
+      expected_date: 2.days.ago.to_date
+    )
+    entry = create_entry(
+      name: recurring_transaction.name,
+      amount: recurring_transaction.amount,
+      date: recurring_transaction.next_expected_date
+    )
+
+    result = Recurring::Reconciler.new(@family).reconcile!.find do |candidate|
+      candidate.commitment == recurring_transaction
+    end
+
+    assert_equal "paid", result.status
+    match_key = "RecurringTransaction:#{recurring_transaction.id}:#{recurring_transaction.next_expected_date}"
+    assert_equal recurring_transaction.id, entry.transaction.reload.extra.dig("recurring_matches", match_key, "commitment_id")
+    assert_equal 1, recurring_transaction.audit_logs.where(event: "recurring.paid").count
+
+    Recurring::Reconciler.new(@family).reconcile!
+
+    assert_equal 1, recurring_transaction.audit_logs.where(event: "recurring.paid").count
+  end
+
+  test "classifies duplicate and missed occurrences" do
+    duplicate = create_recurring_transaction(
+      name: "Duplicate Membership",
+      expected_date: 2.days.ago.to_date
+    )
+    2.times do
+      create_entry(
+        name: duplicate.name,
+        amount: duplicate.amount,
+        date: duplicate.next_expected_date
+      )
+    end
+    missed = create_recurring_transaction(
+      name: "Missing Membership",
+      expected_date: 10.days.ago.to_date
+    )
+
+    results = Recurring::Reconciler.new(@family).reconcile!
+
+    assert_equal "duplicate", results.find { |result| result.commitment == duplicate }.status
+    assert_equal "missed", results.find { |result| result.commitment == missed }.status
+  end
+
+  test "flags a charge for a paused subscription as an unexpected renewal" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(status: "paused", amount: 22, merchant: @merchant)
+    create_entry(
+      name: subscription.name,
+      amount: subscription.amount,
+      date: Date.current
+    ).transaction.update!(merchant: subscription.merchant)
+
+    result = Recurring::Reconciler.new(@family).reconcile!.find do |candidate|
+      candidate.commitment == subscription
+    end
+
+    assert_equal "unexpected_renewal", result.status
+    assert subscription.audit_logs.where(event: "recurring.unexpected_renewal").exists?
+  end
+
+  test "matches a merchantless manual transaction by normalized service name" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.update!(status: "paused", amount: 22, merchant: @merchant)
+    entry = create_entry(
+      name: "Subscription: #{@merchant.name}",
+      amount: subscription.amount,
+      date: Date.current
+    )
+
+    result = Recurring::Reconciler.new(
+      @family,
+      as_of: entry.date,
+      entry: entry
+    ).reconcile!.find { |candidate| candidate.commitment == subscription }
+
+    assert_equal "unexpected_renewal", result.status
+    assert_equal [ entry ], result.entries
+  end
+
+  test "reconciles the latest renewal after next billing advances" do
+    subscription = subscription_plans(:netflix_subscription)
+    expected_date = Date.current
+    subscription.update!(
+      amount: 100,
+      merchant: @merchant,
+      next_billing_at: expected_date.next_month
+    )
+    entry = create_entry(
+      name: subscription.name,
+      amount: 125,
+      date: expected_date
+    )
+    entry.transaction.update!(merchant: @merchant)
+    subscription.subscription_renewals.create!(
+      account: @account,
+      entry: entry,
+      cycle_number: subscription.next_cycle_number,
+      billing_period_start: expected_date,
+      billing_period_end: expected_date.next_month,
+      template_amount: 100,
+      actual_amount: 125,
+      currency: "USD",
+      paid_at: expected_date,
+      status: "paid"
+    )
+
+    result = Recurring::Reconciler.new(@family, as_of: expected_date).reconcile!.find do |candidate|
+      candidate.commitment == subscription && candidate.expected_date == expected_date
+    end
+
+    assert_equal "amount_changed", result.status
+    assert_equal [ entry.id ], result.entries.map(&:id)
+    assert subscription.audit_logs.where(event: "recurring.amount_changed").exists?
+  end
+
+  test "matching a current subscription payment advances its schedule" do
+    subscription = subscription_plans(:netflix_subscription)
+    expected_date = Date.current
+    subscription.subscription_renewals.destroy_all
+    subscription.update!(
+      amount: 25,
+      merchant: @merchant,
+      next_billing_at: expected_date
+    )
+    entry = create_entry(
+      name: subscription.name,
+      amount: subscription.amount,
+      date: expected_date
+    )
+    entry.transaction.update!(merchant: @merchant)
+
+    Recurring::Reconciler.new(
+      @family,
+      as_of: expected_date,
+      entry: entry
+    ).reconcile!
+
+    assert_equal expected_date.next_month, subscription.reload.next_billing_at
+    assert_equal entry, subscription.subscription_renewals.last.entry
+  end
+
+  private
+    def create_recurring_transaction(name:, expected_date:)
+      @family.recurring_transactions.create!(
+        name: name,
+        account: @account,
+        amount: 42,
+        currency: "USD",
+        expected_day_of_month: expected_date.day,
+        last_occurrence_date: expected_date.prev_month,
+        next_expected_date: expected_date,
+        status: "active",
+        occurrence_count: 4
+      )
+    end
+
+    def create_entry(name:, amount:, date:)
+      @account.entries.create!(
+        name: name,
+        amount: amount,
+        currency: "USD",
+        date: date,
+        entryable: Transaction.new
+      )
+    end
+end

--- a/test/models/recurring/schedule_test.rb
+++ b/test/models/recurring/schedule_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Recurring::ScheduleTest < ActiveSupport::TestCase
+  test "advances flexible intervals" do
+    assert_equal Date.new(2026, 6, 10), Recurring::Schedule.new(count: 3, unit: "day").advance(Date.new(2026, 6, 7))
+    assert_equal Date.new(2026, 6, 21), Recurring::Schedule.new(count: 2, unit: "week").advance(Date.new(2026, 6, 7))
+    assert_equal Date.new(2026, 8, 7), Recurring::Schedule.new(count: 2, unit: "month").advance(Date.new(2026, 6, 7))
+  end
+
+  test "uses calendar-safe month advancement" do
+    schedule = Recurring::Schedule.new(count: 1, unit: "month")
+
+    assert_equal Date.new(2026, 2, 28), schedule.advance(Date.new(2026, 1, 31))
+    assert_equal Date.new(2028, 2, 29), schedule.advance(Date.new(2028, 1, 31))
+  end
+
+  test "projects legacy cycles and readable labels" do
+    subscription = subscription_plans(:netflix_subscription)
+    subscription.billing_cycle = "quarterly"
+
+    schedule = Recurring::Schedule.from_subscription(subscription)
+
+    assert_equal 3, schedule.count
+    assert_equal "month", schedule.unit
+    assert_equal "Every 3 months", schedule.label
+  end
+
+  test "one-time schedules do not advance" do
+    schedule = Recurring::Schedule.new(count: 1, unit: "once")
+
+    assert_nil schedule.advance(Date.current)
+    assert_equal "One-time", schedule.label
+  end
+
+  test "round trips a flexible service frequency" do
+    service = ServiceMerchant.new(billing_frequency: "2_week")
+    schedule = Recurring::Schedule.from_service_merchant(service)
+
+    assert_equal 2, schedule.count
+    assert_equal "week", schedule.unit
+    assert_equal "2_week", schedule.service_frequency
+    assert_equal "Every 2 weeks", schedule.label
+  end
+end

--- a/test/models/recurring_transaction/identifier_test.rb
+++ b/test/models/recurring_transaction/identifier_test.rb
@@ -166,6 +166,34 @@ class RecurringTransaction::IdentifierTest < ActiveSupport::TestCase
     assert_equal 0, @family.recurring_transactions.count
   end
 
+  test "identifies a weekly cadence without forcing day-of-month clustering" do
+    account = @family.accounts.first
+    merchant = merchants(:amazon)
+    dates = [ 21, 14, 7, 0 ].map { |days_ago| days_ago.days.ago.to_date }
+
+    dates.each do |date|
+      account.entries.create!(
+        date: date,
+        amount: 12,
+        currency: "USD",
+        name: "Weekly service",
+        entryable: Transaction.new(
+          merchant: merchant,
+          category: categories(:food_and_drink)
+        )
+      )
+    end
+
+    assert_difference "@family.recurring_transactions.count", 1 do
+      @identifier.identify_recurring_patterns
+    end
+
+    recurring = @family.recurring_transactions.first
+    assert_equal 1, recurring.schedule.count
+    assert_equal "week", recurring.schedule.unit
+    assert_equal dates.max + 1.week, recurring.next_expected_date
+  end
+
   test "updates existing recurring transaction when pattern is found again" do
     account = @family.accounts.first
     merchant = merchants(:amazon)  # Use different merchant to avoid fixture conflicts
@@ -206,6 +234,145 @@ class RecurringTransaction::IdentifierTest < ActiveSupport::TestCase
     assert_equal "active", recurring.status
     # Verify last_occurrence_date was updated
     assert recurring.last_occurrence_date >= 2.months.ago.to_date
+  end
+
+  test "identifies same merchant amount separately per account" do
+    merchant = merchants(:netflix)
+    accounts = [ accounts(:depository), accounts(:credit_card) ]
+
+    accounts.each do |account|
+      [ 0, 1, 2 ].each do |months_ago|
+        transaction = Transaction.create!(
+          merchant: merchant,
+          category: categories(:food_and_drink)
+        )
+        account.entries.create!(
+          date: months_ago.months.ago.beginning_of_month + 4.days,
+          amount: 15.99,
+          currency: "USD",
+          name: "Netflix Subscription",
+          entryable: transaction
+        )
+      end
+    end
+
+    assert_difference "@family.recurring_transactions.count", 2 do
+      @identifier.identify_recurring_patterns
+    end
+
+    detected_account_ids = @family.recurring_transactions.pluck(:account_id)
+    assert_equal accounts.map(&:id).sort, detected_account_ids.sort
+  end
+
+  test "does not recreate physically deleted suppressed recurring transaction" do
+    account = @family.accounts.first
+    merchant = merchants(:amazon)
+
+    [ 0, 1, 2 ].each do |months_ago|
+      transaction = Transaction.create!(
+        merchant: merchant,
+        category: categories(:food_and_drink)
+      )
+      account.entries.create!(
+        date: months_ago.months.ago.beginning_of_month + 14.days,
+        amount: 29.99,
+        currency: "USD",
+        name: "Amazon Purchase",
+        entryable: transaction
+      )
+    end
+
+    recurring = @family.recurring_transactions.create!(
+      account: account,
+      merchant: merchant,
+      amount: 29.99,
+      currency: "USD",
+      expected_day_of_month: 15,
+      last_occurrence_date: 2.months.ago.to_date,
+      next_expected_date: 1.month.ago.to_date,
+      occurrence_count: 2,
+      status: "active"
+    )
+
+    recurring.ignore!
+    recurring.destroy!
+
+    assert_no_difference "@family.recurring_transactions.count" do
+      @identifier.identify_recurring_patterns
+    end
+  end
+
+  test "does not reactivate inactive recurring transaction when pattern is found again" do
+    account = @family.accounts.first
+    merchant = merchants(:amazon)
+
+    existing = @family.recurring_transactions.create!(
+      merchant: merchant,
+      amount: 29.99,
+      currency: "USD",
+      expected_day_of_month: 15,
+      last_occurrence_date: 2.months.ago.to_date,
+      next_expected_date: 1.month.ago.to_date,
+      occurrence_count: 2,
+      status: "inactive"
+    )
+
+    [ 0, 1, 2 ].each do |months_ago|
+      transaction = Transaction.create!(
+        merchant: merchant,
+        category: categories(:food_and_drink)
+      )
+      account.entries.create!(
+        date: months_ago.months.ago.beginning_of_month + 14.days,
+        amount: 29.99,
+        currency: "USD",
+        name: "Amazon Purchase",
+        entryable: transaction
+      )
+    end
+
+    assert_no_difference "@family.recurring_transactions.count" do
+      @identifier.identify_recurring_patterns
+    end
+
+    assert_equal "inactive", existing.reload.status
+    assert existing.last_occurrence_date >= 2.months.ago.to_date
+  end
+
+  test "does not recreate ignored recurring transaction when pattern is found again" do
+    account = @family.accounts.first
+    merchant = merchants(:amazon)
+
+    ignored = @family.recurring_transactions.create!(
+      merchant: merchant,
+      amount: 29.99,
+      currency: "USD",
+      expected_day_of_month: 15,
+      last_occurrence_date: 2.months.ago.to_date,
+      next_expected_date: 1.month.ago.to_date,
+      occurrence_count: 2,
+      status: "ignored"
+    )
+
+    [ 0, 1, 2 ].each do |months_ago|
+      transaction = Transaction.create!(
+        merchant: merchant,
+        category: categories(:food_and_drink)
+      )
+      account.entries.create!(
+        date: months_ago.months.ago.beginning_of_month + 14.days,
+        amount: 29.99,
+        currency: "USD",
+        name: "Amazon Purchase",
+        entryable: transaction
+      )
+    end
+
+    assert_no_difference "@family.recurring_transactions.count" do
+      @identifier.identify_recurring_patterns
+    end
+
+    assert_equal "ignored", ignored.reload.status
   end
 
   test "circular_distance calculates correct distance for days near month boundary" do

--- a/test/models/recurring_transaction_test.rb
+++ b/test/models/recurring_transaction_test.rb
@@ -60,6 +60,72 @@ class RecurringTransactionTest < ActiveSupport::TestCase
     end
   end
 
+  test "identify_patterns_for excludes transfer transactions" do
+    account = @family.accounts.first
+
+    [ 0, 1, 2 ].each do |months_ago|
+      transaction = Transaction.create!(
+        kind: "funds_movement",
+        merchant: @merchant,
+        category: categories(:food_and_drink)
+      )
+      account.entries.create!(
+        date: months_ago.months.ago.beginning_of_month + 5.days,
+        amount: 500,
+        currency: "USD",
+        name: "Monthly account transfer",
+        entryable: transaction
+      )
+    end
+
+    assert_no_difference "@family.recurring_transactions.count" do
+      RecurringTransaction.identify_patterns_for(@family)
+    end
+  end
+
+  test "identity signature normalizes names, amounts, and currency" do
+    signature = RecurringTransaction.identity_signature_for(
+      account_id: accounts(:depository).id,
+      destination_account_id: nil,
+      merchant_id: nil,
+      name: "  Gym   Membership ",
+      amount: "25.0000",
+      currency: "usd"
+    )
+    equivalent_signature = RecurringTransaction.identity_signature_for(
+      account_id: accounts(:depository).id,
+      destination_account_id: nil,
+      merchant_id: nil,
+      name: "gym membership",
+      amount: "25.00",
+      currency: "USD"
+    )
+
+    assert_equal signature, equivalent_signature
+  end
+
+  test "identity signature distinguishes recurring transfer destinations" do
+    source = accounts(:depository)
+    common = {
+      account_id: source.id,
+      merchant_id: nil,
+      name: "Monthly transfer",
+      amount: 100,
+      currency: "USD"
+    }
+
+    credit_card_signature = RecurringTransaction.identity_signature_for(
+      **common,
+      destination_account_id: accounts(:credit_card).id
+    )
+    investment_signature = RecurringTransaction.identity_signature_for(
+      **common,
+      destination_account_id: accounts(:investment).id
+    )
+
+    assert_not_equal credit_card_signature, investment_signature
+  end
+
   test "calculate_next_expected_date handles end of month correctly" do
     recurring = @family.recurring_transactions.create!(
       merchant: @merchant,
@@ -139,6 +205,156 @@ class RecurringTransactionTest < ActiveSupport::TestCase
     assert_equal 4, recurring.occurrence_count
     assert_equal "active", recurring.status
     assert recurring.next_expected_date > new_date
+  end
+
+  test "ignore! suppresses recurring transaction without deleting detection memory" do
+    recurring = @family.recurring_transactions.create!(
+      merchant: merchants(:amazon),
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: Date.current,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    assert_no_difference "RecurringTransaction.count" do
+      recurring.ignore!
+    end
+
+    assert_equal "ignored", recurring.reload.status
+    assert_not_includes @family.recurring_transactions.visible, recurring
+  end
+
+  test "record_occurrence! does not reactivate ignored recurring transaction" do
+    recurring = @family.recurring_transactions.create!(
+      merchant: merchants(:amazon),
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: 1.month.ago.to_date,
+      next_expected_date: Date.current,
+      status: "ignored",
+      occurrence_count: 3
+    )
+
+    assert_no_changes "recurring.reload.status" do
+      assert_equal false, recurring.record_occurrence!(Date.current)
+    end
+  end
+
+  test "create_subscription_plan! creates subscription and suppresses recurring candidate" do
+    account = @family.accounts.first
+    merchant = merchants(:amazon)
+
+    [ 0, 1, 2 ].each do |months_ago|
+      transaction = Transaction.create!(
+        merchant: merchant,
+        category: categories(:food_and_drink)
+      )
+      account.entries.create!(
+        date: months_ago.months.ago.beginning_of_month + 5.days,
+        amount: 45.99,
+        currency: "USD",
+        name: "Amazon Prime",
+        entryable: transaction
+      )
+    end
+
+    recurring = @family.recurring_transactions.create!(
+      merchant: merchant,
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    assert_difference "SubscriptionPlan.count", 1 do
+      @subscription_plan = recurring.create_subscription_plan!
+    end
+
+    assert_equal "ignored", recurring.reload.status
+    assert_equal account, @subscription_plan.account
+    assert_equal merchant, @subscription_plan.merchant
+    assert_equal "Amazon", @subscription_plan.name
+    assert_equal recurring.amount, @subscription_plan.amount
+    assert_equal recurring.next_expected_date, @subscription_plan.next_billing_at
+    assert_equal recurring.id, @subscription_plan.metadata.dig("source", "id")
+  end
+
+  test "create_subscription_plan! reuses existing matching subscription" do
+    merchant = merchants(:amazon)
+    existing = @family.subscription_plans.create!(
+      account: @family.accounts.first,
+      merchant: merchant,
+      name: "Amazon",
+      amount: 45.99,
+      currency: "USD",
+      billing_cycle: "monthly",
+      status: "active",
+      payment_method: "manual",
+      started_at: 1.month.ago.to_date,
+      next_billing_at: 1.month.from_now.to_date,
+      auto_renew: true
+    )
+
+    recurring = @family.recurring_transactions.create!(
+      merchant: merchant,
+      amount: 45.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    assert_no_difference "SubscriptionPlan.count" do
+      assert_equal existing, recurring.create_subscription_plan!
+    end
+
+    assert_equal "ignored", recurring.reload.status
+  end
+
+  test "create_subscription_plan! rejects recurring income" do
+    recurring = @family.recurring_transactions.create!(
+      merchant: merchants(:amazon),
+      amount: -1000.00,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 3
+    )
+
+    assert_no_difference "SubscriptionPlan.count" do
+      error = assert_raises(ArgumentError) { recurring.create_subscription_plan! }
+      assert_equal "Only recurring expenses can become subscription plans", error.message
+    end
+  end
+
+  test "create_subscription_plan! rejects recurring transfers" do
+    recurring = @family.recurring_transactions.create!(
+      account: accounts(:depository),
+      destination_account: accounts(:credit_card),
+      name: "Card payment",
+      amount: 100,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active",
+      occurrence_count: 1,
+      manual: true
+    )
+
+    assert_not recurring.subscription_candidate?
+    assert_raises(ArgumentError) { recurring.create_subscription_plan! }
   end
 
   test "identify_patterns_for preserves sign for income transactions" do
@@ -263,6 +479,91 @@ class RecurringTransactionTest < ActiveSupport::TestCase
     matches = recurring.matching_transactions
     assert_equal 3, matches.size
     assert matches.all? { |entry| entry.name == "Gym Membership" }
+  end
+
+  test "matching_transactions excludes transfer transactions with the same merchant and amount" do
+    account = @family.accounts.first
+    recurring = @family.recurring_transactions.create!(
+      account: account,
+      merchant: @merchant,
+      amount: 15.99,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      status: "active"
+    )
+
+    standard = Transaction.create!(merchant: @merchant, kind: "standard")
+    transfer = Transaction.create!(merchant: @merchant, kind: "funds_movement")
+
+    standard_entry = account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: 15.99,
+      currency: "USD",
+      name: "Netflix",
+      entryable: standard
+    )
+    account.entries.create!(
+      date: Date.current.beginning_of_month + 4.days,
+      amount: 15.99,
+      currency: "USD",
+      name: "Netflix",
+      entryable: transfer
+    )
+
+    assert_equal [ standard_entry.id ], recurring.matching_transactions.pluck(:id)
+  end
+
+  test "create_from_transfer stores both endpoints and matches the transfer pair" do
+    source = accounts(:depository)
+    destination = accounts(:credit_card)
+    date = Date.current.beginning_of_month + 4.days
+    outflow = source.entries.create!(
+      date: date,
+      amount: 250,
+      currency: "USD",
+      name: "Card payment",
+      entryable: Transaction.new(kind: "cc_payment")
+    )
+    inflow = destination.entries.create!(
+      date: date,
+      amount: -250,
+      currency: "USD",
+      name: "Card payment",
+      entryable: Transaction.new(kind: "funds_movement")
+    )
+    transfer = Transfer.create!(
+      outflow_transaction: outflow.entryable,
+      inflow_transaction: inflow.entryable,
+      status: "confirmed"
+    )
+
+    recurring = RecurringTransaction.create_from_transfer(transfer)
+
+    assert recurring.transfer?
+    assert_equal source, recurring.account
+    assert_equal destination, recurring.destination_account
+    assert_equal [ outflow.id ], recurring.matching_transactions.pluck(:id)
+    assert_equal source, recurring.projected_entry.source_account
+    assert_equal destination, recurring.projected_entry.destination_account
+  end
+
+  test "recurring transfer rejects identical endpoints" do
+    recurring = @family.recurring_transactions.build(
+      account: accounts(:depository),
+      destination_account: accounts(:depository),
+      name: "Invalid transfer",
+      amount: 100,
+      currency: "USD",
+      expected_day_of_month: 5,
+      last_occurrence_date: Date.current,
+      next_expected_date: 1.month.from_now.to_date,
+      manual: true
+    )
+
+    assert_not recurring.valid?
+    assert_includes recurring.errors[:destination_account], "cannot be the same as the source account"
   end
 
   test "validation requires either merchant or name" do


### PR DESCRIPTION
## Summary
- introduce an account-scoped recurring candidate model with persistent suppression signatures
- identify, confirm, ignore, restore, and convert recurring patterns without rediscovery loops
- reconcile transaction entries against subscription renewals and recurring commitments with pending, matched, missed, duplicate, and unexpected states
- support recurring transfers, projected budget commitments, anomaly email notifications, and a unified Recurring workspace
- debounce post-sync identification and reconcile changed transaction entries asynchronously

## Data safety
- backfill recurring account scope from matching family transactions
- deduplicate candidates before replacing legacy uniqueness with identity signatures
- enforce source/destination transfer constraints and family-scoped suppression uniqueness
- validate migration down/up behavior on disposable PostgreSQL 18

## Verification
- focused recurring suite: 117 runs, 436 assertions, 0 failures, 0 errors
- full suite: 1877 runs, 9135 assertions, 0 failures, 0 errors, 19 skips
- `bin/rubocop`: 1265 files, no offenses
- `npm run lint`: 95 files, no issues
- `bin/brakeman --no-pager`: 0 security warnings
