### PR TITLE
Add reproducible PostgreSQL 18 test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres -d sure_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,42 @@ jobs:
 
       - name: Lint/Format js code
         run: pnpm run lint
+
+  test:
+    name: Test Suite (PostgreSQL 18)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [lint, lint_js]
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: sure_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Run test suite
+        run: bin/test-db --ci -- bin/rails test
+        env:
+          RAILS_ENV: test
+          DB_HOST: localhost
+          DB_PORT: 5432
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB_TEST: sure_test

--- a/.gitignore
+++ b/.gitignore
@@ -136,8 +136,5 @@ credentials.json
 # Catchup analysis (not for commit)
 docs/CATCHUP_SURE_COMMUNITY.md
 
-# Project planning artifacts (not for commit)
-CONTEXT.md
-docs/adr/
-docs/agents/
-issues/
+# Catchup analysis (not for commit)
+docs/CATCHUP_SURE_COMMUNITY.md

--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,8 @@ credentials.json
 # Catchup analysis (not for commit)
 docs/CATCHUP_SURE_COMMUNITY.md
 
-# Catchup analysis (not for commit)
-docs/CATCHUP_SURE_COMMUNITY.md
+# Project planning artifacts (not for commit)
+CONTEXT.md
+docs/adr/
+docs/agents/
+issues/

--- a/bin/test-db
+++ b/bin/test-db
@@ -79,7 +79,7 @@ start_container() {
     --rm \
     -p "127.0.0.1:${HARNESS_DB_PORT}:5432" \
     --tmpfs /var/lib/postgresql \
-    --health-cmd pg_isready \
+    --health-cmd "pg_isready -U ${HARNESS_DB_USER} -d ${HARNESS_DB_NAME}" \
     --health-interval 2s \
     --health-timeout 5s \
     --health-retries 10 \
@@ -169,11 +169,29 @@ write_probe_script() {
   local tmpfile="$1"
   cat > "$tmpfile" <<'RUBY'
 c = ActiveRecord::Base.connection_db_config.configuration_hash
-puts "adapter=#{c[:adapter]}"
-puts "host=#{c[:host] || 'localhost'}"
-puts "port=#{c[:port] || 5432}"
-puts "database=#{c[:database]}"
+
+actual = {
+  adapter: c[:adapter].to_s,
+  host: (c[:host] || "localhost").to_s,
+  port: (c[:port] || 5432).to_i,
+  database: c[:database].to_s
+}
+expected = {
+  adapter: "postgresql",
+  host: ENV.fetch("DB_HOST"),
+  port: Integer(ENV.fetch("DB_PORT"), 10),
+  database: ENV.fetch("POSTGRES_DB_TEST")
+}
+
+mismatches = expected.filter_map do |key, expected_value|
+  actual_value = actual.fetch(key)
+  "#{key}=#{actual_value.inspect} (expected #{expected_value.inspect})" unless actual_value == expected_value
+end
+
+abort "Database configuration mismatch: #{mismatches.join(', ')}" if mismatches.any?
+
 ActiveRecord::Base.connection.execute("SELECT 1")
+actual.each { |key, value| puts "#{key}=#{value}" }
 puts "ok=true"
 RUBY
 }
@@ -189,7 +207,6 @@ boot_probe() {
   local probe_output
   set +e
   probe_output=$(cd "$PROJECT_ROOT" && \
-    ALLOW_PRODUCTION_DB_TASKS=1 \
     RAILS_ENV=test \
     DB_HOST="$HARNESS_DB_HOST" \
     DB_PORT="$HARNESS_DB_PORT" \
@@ -205,7 +222,7 @@ boot_probe() {
   if [ "$probe_exit" -ne 0 ]; then
     fail "Boot probe failed."
     echo "$probe_output" >&2
-    die "Rails could not connect. Check that PostgreSQL is running and credentials are correct."
+    die "Rails database probe failed. Review the configuration or connection error above."
   fi
 
   local adapter host port database probe_ok
@@ -235,8 +252,7 @@ load_schema() {
 
   cd "$PROJECT_ROOT"
 
-  ALLOW_PRODUCTION_DB_TASKS=1 \
-    RAILS_ENV=test \
+  RAILS_ENV=test \
     DB_HOST="$HARNESS_DB_HOST" \
     DB_PORT="$HARNESS_DB_PORT" \
     POSTGRES_USER="$HARNESS_DB_USER" \
@@ -275,6 +291,12 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "$CI_MODE" -eq 1 ]; then
+  HARNESS_DB_PASSWORD="${POSTGRES_PASSWORD:-}"
+  HARNESS_DB_HOST="${DB_HOST:-127.0.0.1}"
+  HARNESS_DB_PORT="${DB_PORT:-5432}"
+fi
+
 if [ ${#CMD_ARGS[@]} -eq 0 ] && [ -z "$SUBCOMMAND" ] && [ "$CI_MODE" -eq 0 ]; then
   CMD_ARGS=(bin/rails test)
 fi
@@ -288,11 +310,6 @@ esac
 if [ "$CI_MODE" -eq 0 ]; then
   command -v docker >/dev/null 2>&1 || die "Docker is not available. Install Docker or use --ci mode."
   docker info >/dev/null 2>&1 || die "Docker daemon is not running. Start Docker or use --ci mode."
-fi
-
-if [ "$CI_MODE" -eq 1 ]; then
-  HARNESS_DB_PASSWORD="${POSTGRES_PASSWORD:-${HARNESS_DB_PASSWORD}}"
-  HARNESS_DB_HOST="${DB_HOST:-${HARNESS_DB_HOST}}"
 fi
 
 # --- Execute ----------------------------------------------------------------
@@ -330,16 +347,16 @@ if [ ${#CMD_ARGS[@]} -gt 0 ]; then
 
   cd "$PROJECT_ROOT"
 
-  ALLOW_PRODUCTION_DB_TASKS=1 \
-    RAILS_ENV=test \
+  set +e
+  RAILS_ENV=test \
     DB_HOST="$HARNESS_DB_HOST" \
     DB_PORT="$HARNESS_DB_PORT" \
     POSTGRES_USER="$HARNESS_DB_USER" \
     POSTGRES_PASSWORD="$HARNESS_DB_PASSWORD" \
     POSTGRES_DB_TEST="$HARNESS_DB_NAME" \
     "${CMD_ARGS[@]}"
-
   exit_code=$?
+  set -e
 
   echo ""
   if [ $exit_code -eq 0 ]; then

--- a/bin/test-db
+++ b/bin/test-db
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# bin/test-db — Disposable PostgreSQL 18 test database harness
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Configuration ---------------------------------------------------------
+HARNESS_DB_PORT="${TEST_DB_PORT:-5436}"
+HARNESS_DB_PASSWORD="${TEST_DB_PASSWORD:-$(openssl rand -hex 16 2>/dev/null || echo "test-$(date +%s)")}"
+HARNESS_DB_NAME="${POSTGRES_DB_TEST:-sure_test}"
+HARNESS_DB_USER="${POSTGRES_USER:-postgres}"
+HARNESS_DB_HOST="${TEST_DB_HOST:-127.0.0.1}"
+HARNESS_DB_CONTAINER="${TEST_DB_CONTAINER:-sure-test-db}"
+POSTGRES_IMAGE="postgres:18"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ok()   { printf "  ${GREEN}✓${NC} %s\n" "$1"; }
+fail() { printf "  ${RED}✗${NC} %s\n" "$1"; }
+warn() { printf "  ${YELLOW}⚠${NC} %s\n" "$1"; }
+die()  { printf "${RED}ERROR:${NC} %s\n" "$1" >&2; exit 1; }
+
+# --- Usage ------------------------------------------------------------------
+usage() {
+  cat <<'EOF'
+Usage: bin/test-db [--keep] [--ci] [start|stop|status] [-- <command>]
+
+Manage a disposable PostgreSQL 18 test database.
+
+Commands:
+  start         Start container and print connection environment variables.
+  stop          Stop and remove the test container.
+  status        Show whether the test container is running.
+
+Options:
+  --keep        Keep the container running after the command completes.
+  --ci          Do not manage a container — assume PostgreSQL is already
+                available (for CI services-block workflows).
+  -- <command>  Run this command instead of 'bin/rails test'.
+
+Examples:
+  bin/test-db                           # Full lifecycle
+  bin/test-db -- bin/rails test:models  # Run only model tests
+  bin/test-db --keep -- bin/rails test  # Keep container for inspection
+  bin/test-db start                     # Start container, keep running
+  bin/test-db --ci -- bin/rails test    # CI mode: use external PostgreSQL
+EOF
+  exit 0
+}
+
+# --- Container lifecycle ----------------------------------------------------
+start_container() {
+  if docker ps --format '{{.Names}}' 2>/dev/null | grep -qxF "$HARNESS_DB_CONTAINER"; then
+    warn "Container '$HARNESS_DB_CONTAINER' is already running."
+    return 0
+  fi
+
+  if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qxF "$HARNESS_DB_CONTAINER"; then
+    warn "Container '$HARNESS_DB_CONTAINER' exists but is stopped. Removing..."
+    docker rm -f "$HARNESS_DB_CONTAINER" >/dev/null 2>&1 || true
+  fi
+
+  if command -v ss >/dev/null 2>&1; then
+    if ss -tln "sport = :$HARNESS_DB_PORT" 2>/dev/null | grep -q ":$HARNESS_DB_PORT"; then
+      die "Port $HARNESS_DB_PORT is already in use. Set TEST_DB_PORT to a different port."
+    fi
+  fi
+
+  echo "Starting disposable PostgreSQL 18 container..."
+  docker run -d \
+    --name "$HARNESS_DB_CONTAINER" \
+    --rm \
+    -p "127.0.0.1:${HARNESS_DB_PORT}:5432" \
+    --tmpfs /var/lib/postgresql \
+    --health-cmd pg_isready \
+    --health-interval 2s \
+    --health-timeout 5s \
+    --health-retries 10 \
+    -e "POSTGRES_USER=${HARNESS_DB_USER}" \
+    -e "POSTGRES_PASSWORD=${HARNESS_DB_PASSWORD}" \
+    -e "POSTGRES_DB=${HARNESS_DB_NAME}" \
+    "$POSTGRES_IMAGE" >/dev/null
+
+  ok "Container '$HARNESS_DB_CONTAINER' started on port $HARNESS_DB_PORT."
+}
+
+wait_for_postgres() {
+  local max_attempts=30
+  local attempt=1
+
+  while [ $attempt -le $max_attempts ]; do
+    if docker exec "$HARNESS_DB_CONTAINER" pg_isready -U "$HARNESS_DB_USER" -d "$HARNESS_DB_NAME" >/dev/null 2>&1; then
+      ok "PostgreSQL is ready (attempt ${attempt}/${max_attempts})."
+      return 0
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+
+  die "PostgreSQL did not become ready within ${max_attempts}s."
+}
+
+stop_container() {
+  if docker ps --format '{{.Names}}' 2>/dev/null | grep -qxF "$HARNESS_DB_CONTAINER"; then
+    echo "Stopping container '$HARNESS_DB_CONTAINER'..."
+    docker stop "$HARNESS_DB_CONTAINER" >/dev/null 2>&1
+    ok "Container stopped."
+  elif docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qxF "$HARNESS_DB_CONTAINER"; then
+    echo "Removing stopped container '$HARNESS_DB_CONTAINER'..."
+    docker rm -f "$HARNESS_DB_CONTAINER" >/dev/null 2>&1
+    ok "Container removed."
+  else
+    warn "Container '$HARNESS_DB_CONTAINER' not found."
+  fi
+}
+
+cleanup() {
+  if [ "${KEEP_CONTAINER:-0}" -eq 1 ]; then
+    warn "Container '$HARNESS_DB_CONTAINER' left running on port $HARNESS_DB_PORT (--keep)."
+    return
+  fi
+  stop_container
+}
+
+show_status() {
+  if docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' 2>/dev/null | grep -qF "$HARNESS_DB_CONTAINER"; then
+    echo "Container status:"
+    docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | head -1
+    docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | grep "$HARNESS_DB_CONTAINER"
+  else
+    warn "Container '$HARNESS_DB_CONTAINER' is not running."
+    return 1
+  fi
+}
+
+print_env() {
+  echo ""
+  echo "Connection environment variables:"
+  echo ""
+  echo "  export RAILS_ENV=test"
+  echo "  export DB_HOST=${HARNESS_DB_HOST}"
+  echo "  export DB_PORT=${HARNESS_DB_PORT}"
+  echo "  export POSTGRES_USER=${HARNESS_DB_USER}"
+  echo "  export POSTGRES_PASSWORD=${HARNESS_DB_PASSWORD}"
+  echo "  export POSTGRES_DB_TEST=${HARNESS_DB_NAME}"
+  echo ""
+}
+
+cmd_env() {
+  cat <<EOF
+export RAILS_ENV=test
+export DB_HOST=${HARNESS_DB_HOST}
+export DB_PORT=${HARNESS_DB_PORT}
+export POSTGRES_USER=${HARNESS_DB_USER}
+export POSTGRES_PASSWORD=${HARNESS_DB_PASSWORD}
+export POSTGRES_DB_TEST=${HARNESS_DB_NAME}
+EOF
+}
+
+# --- Boot probe (Ruby helper) -----------------------------------------------
+write_probe_script() {
+  local tmpfile="$1"
+  cat > "$tmpfile" <<'RUBY'
+c = ActiveRecord::Base.connection_db_config.configuration_hash
+puts "adapter=#{c[:adapter]}"
+puts "host=#{c[:host] || 'localhost'}"
+puts "port=#{c[:port] || 5432}"
+puts "database=#{c[:database]}"
+ActiveRecord::Base.connection.execute("SELECT 1")
+puts "ok=true"
+RUBY
+}
+
+boot_probe() {
+  echo ""
+  echo "--- Boot Probe ---"
+
+  local probe_script
+  probe_script=$(mktemp /tmp/sure-test-db-probe.XXXXXX.rb)
+  write_probe_script "$probe_script"
+
+  local probe_output
+  set +e
+  probe_output=$(cd "$PROJECT_ROOT" && \
+    ALLOW_PRODUCTION_DB_TASKS=1 \
+    RAILS_ENV=test \
+    DB_HOST="$HARNESS_DB_HOST" \
+    DB_PORT="$HARNESS_DB_PORT" \
+    POSTGRES_USER="$HARNESS_DB_USER" \
+    POSTGRES_PASSWORD="$HARNESS_DB_PASSWORD" \
+    POSTGRES_DB_TEST="$HARNESS_DB_NAME" \
+    bin/rails runner "$probe_script" 2>&1)
+  local probe_exit=$?
+  set -e
+
+  rm -f "$probe_script"
+
+  if [ "$probe_exit" -ne 0 ]; then
+    fail "Boot probe failed."
+    echo "$probe_output" >&2
+    die "Rails could not connect. Check that PostgreSQL is running and credentials are correct."
+  fi
+
+  local adapter host port database probe_ok
+  while IFS='=' read -r key value; do
+    case "$key" in
+      adapter)  adapter="$value" ;;
+      host)     host="$value" ;;
+      port)     port="$value" ;;
+      database) database="$value" ;;
+      ok)       probe_ok="$value" ;;
+    esac
+  done <<< "$probe_output"
+
+  if [ "${probe_ok:-}" != "true" ]; then
+    fail "Boot probe returned unexpected output."
+    echo "$probe_output" >&2
+    die "Probe failed."
+  fi
+
+  ok "adapter=${adapter}, host=${host}:${port}, database=${database}"
+}
+
+# --- Schema load ------------------------------------------------------------
+load_schema() {
+  echo ""
+  echo "--- Schema Load ---"
+
+  cd "$PROJECT_ROOT"
+
+  ALLOW_PRODUCTION_DB_TASKS=1 \
+    RAILS_ENV=test \
+    DB_HOST="$HARNESS_DB_HOST" \
+    DB_PORT="$HARNESS_DB_PORT" \
+    POSTGRES_USER="$HARNESS_DB_USER" \
+    POSTGRES_PASSWORD="$HARNESS_DB_PASSWORD" \
+    POSTGRES_DB_TEST="$HARNESS_DB_NAME" \
+    bin/rails db:schema:load || die "Schema load failed."
+
+  ok "Schema loaded into '${HARNESS_DB_NAME}'."
+}
+
+# --- Main -------------------------------------------------------------------
+
+KEEP_CONTAINER=0
+CI_MODE=0
+SUBCOMMAND=""
+CMD_ARGS=()
+PARSING_CMD=false
+
+while [ $# -gt 0 ]; do
+  if [ "$PARSING_CMD" = true ]; then
+    CMD_ARGS+=("$1")
+    shift
+    continue
+  fi
+
+  case "$1" in
+    --help|-h)  usage ;;
+    --keep)     KEEP_CONTAINER=1; shift ;;
+    --ci)       CI_MODE=1; shift ;;
+    start)      SUBCOMMAND="start"; shift ;;
+    stop)       SUBCOMMAND="stop"; shift ;;
+    status)     SUBCOMMAND="status"; shift ;;
+    env)        SUBCOMMAND="env"; shift ;;
+    --)         PARSING_CMD=true; shift ;;
+    *)          die "Unknown argument: $1. Run 'bin/test-db --help' for usage." ;;
+  esac
+done
+
+if [ ${#CMD_ARGS[@]} -eq 0 ] && [ -z "$SUBCOMMAND" ] && [ "$CI_MODE" -eq 0 ]; then
+  CMD_ARGS=(bin/rails test)
+fi
+
+case "$SUBCOMMAND" in
+  env)    cmd_env; exit 0 ;;
+  stop)   stop_container; exit 0 ;;
+  status) show_status; exit 0 ;;
+esac
+
+if [ "$CI_MODE" -eq 0 ]; then
+  command -v docker >/dev/null 2>&1 || die "Docker is not available. Install Docker or use --ci mode."
+  docker info >/dev/null 2>&1 || die "Docker daemon is not running. Start Docker or use --ci mode."
+fi
+
+if [ "$CI_MODE" -eq 1 ]; then
+  HARNESS_DB_PASSWORD="${POSTGRES_PASSWORD:-${HARNESS_DB_PASSWORD}}"
+  HARNESS_DB_HOST="${DB_HOST:-${HARNESS_DB_HOST}}"
+fi
+
+# --- Execute ----------------------------------------------------------------
+
+if [ "$SUBCOMMAND" = "start" ]; then
+  start_container
+  wait_for_postgres
+  print_env
+  exit 0
+fi
+
+echo ""
+echo "============================================"
+if [ "$CI_MODE" -eq 1 ]; then
+  echo "  Sure Test Harness — CI Mode (external PG)"
+else
+  echo "  Sure Test Harness — PostgreSQL 18"
+fi
+echo "============================================"
+echo ""
+
+if [ "$CI_MODE" -eq 0 ]; then
+  trap cleanup EXIT
+  start_container
+  wait_for_postgres
+fi
+
+boot_probe
+load_schema
+
+if [ ${#CMD_ARGS[@]} -gt 0 ]; then
+  echo ""
+  echo "Running: ${CMD_ARGS[*]}"
+  echo ""
+
+  cd "$PROJECT_ROOT"
+
+  ALLOW_PRODUCTION_DB_TASKS=1 \
+    RAILS_ENV=test \
+    DB_HOST="$HARNESS_DB_HOST" \
+    DB_PORT="$HARNESS_DB_PORT" \
+    POSTGRES_USER="$HARNESS_DB_USER" \
+    POSTGRES_PASSWORD="$HARNESS_DB_PASSWORD" \
+    POSTGRES_DB_TEST="$HARNESS_DB_NAME" \
+    "${CMD_ARGS[@]}"
+
+  exit_code=$?
+
+  echo ""
+  if [ $exit_code -eq 0 ]; then
+    ok "Command completed successfully."
+  else
+    fail "Command exited with code ${exit_code}."
+  fi
+
+  exit $exit_code
+fi

--- a/lib/tasks/db_safety.rake
+++ b/lib/tasks/db_safety.rake
@@ -24,6 +24,20 @@ namespace :db do
         production, set ALLOW_PRODUCTION_DB_TASKS=1 explicitly.
       MSG
     end
+
+    if env_name == "test" && target_db.present?
+      pattern_str = ENV["APPROVED_TEST_DATABASES_PATTERN"].presence || "_test$"
+      approved_pattern = Regexp.new(pattern_str)
+      unless target_db.match?(approved_pattern)
+        abort <<~MSG
+          Aborting test database task: '#{target_db}' is not an approved test database.
+
+          Test databases must match the pattern: #{pattern_str.inspect}
+          Set POSTGRES_DB_TEST to a database name matching this pattern, or override with
+          the APPROVED_TEST_DATABASES_PATTERN environment variable.
+        MSG
+      end
+    end
   end
 end
 

--- a/lib/tasks/db_safety.rake
+++ b/lib/tasks/db_safety.rake
@@ -4,7 +4,7 @@
 # production database while working locally. Set ALLOW_PRODUCTION_DB_TASKS=1 to
 # override this guard intentionally (e.g., initial provisioning).
 namespace :db do
-  task :ensure_safe_target do
+  task ensure_safe_target: :load_config do
     next if ENV["ALLOW_PRODUCTION_DB_TASKS"] == "1"
 
     env_name = ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || Rails.env
@@ -27,7 +27,12 @@ namespace :db do
 
     if env_name == "test" && target_db.present?
       pattern_str = ENV["APPROVED_TEST_DATABASES_PATTERN"].presence || "_test$"
-      approved_pattern = Regexp.new(pattern_str)
+      begin
+        approved_pattern = Regexp.new(pattern_str)
+      rescue RegexpError => error
+        abort "APPROVED_TEST_DATABASES_PATTERN is invalid: #{error.message}"
+      end
+
       unless target_db.match?(approved_pattern)
         abort <<~MSG
           Aborting test database task: '#{target_db}' is not an approved test database.
@@ -55,11 +60,7 @@ if defined?(Rake::Task)
   ].each do |task_name|
     begin
       task = Rake::Task[task_name]
-      prereqs = task.instance_variable_get(:@prerequisites) || []
-      unless prereqs.include?("db:ensure_safe_target")
-        prereqs.unshift("db:ensure_safe_target")
-        task.instance_variable_set(:@prerequisites, prereqs)
-      end
+      task.enhance([ "db:ensure_safe_target" ]) unless task.prerequisites.include?("db:ensure_safe_target")
     rescue RuntimeError
       # Ignore tasks that may not be defined in the current environment
     end

--- a/test/bin/test_db_test.rb
+++ b/test/bin/test_db_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "open3"
+
+class TestDbTest < ActiveSupport::TestCase
+  test "CI env uses the external PostgreSQL connection settings" do
+    stdout, stderr, status = Open3.capture3(
+      {
+        "DB_HOST" => "postgres.internal",
+        "DB_PORT" => "5544",
+        "POSTGRES_USER" => "ci_user",
+        "POSTGRES_PASSWORD" => "ci_password",
+        "POSTGRES_DB_TEST" => "sure_ci_test",
+        "TEST_DB_HOST" => nil,
+        "TEST_DB_PORT" => nil,
+        "TEST_DB_PASSWORD" => nil
+      },
+      Rails.root.join("bin/test-db").to_s,
+      "--ci",
+      "env"
+    )
+
+    assert status.success?, stderr
+    assert_includes stdout, "export DB_HOST=postgres.internal"
+    assert_includes stdout, "export DB_PORT=5544"
+    assert_includes stdout, "export POSTGRES_USER=ci_user"
+    assert_includes stdout, "export POSTGRES_PASSWORD=ci_password"
+    assert_includes stdout, "export POSTGRES_DB_TEST=sure_ci_test"
+  end
+end

--- a/test/lib/tasks/db_safety_test.rb
+++ b/test/lib/tasks/db_safety_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DbSafetyTaskTest < ActiveSupport::TestCase
+  test "db:ensure_safe_target passes when DB name matches _test pattern" do
+    Rails.application.load_tasks
+    Rake::Task["db:ensure_safe_target"].reenable
+    ClimateControl.modify RAILS_ENV: "test" do
+      Rake::Task["db:ensure_safe_target"].invoke
+    end
+  end
+
+  test "db:ensure_safe_target is bypassed with ALLOW_PRODUCTION_DB_TASKS=1" do
+    Rails.application.load_tasks
+    Rake::Task["db:ensure_safe_target"].reenable
+    ClimateControl.modify ALLOW_PRODUCTION_DB_TASKS: "1" do
+      Rake::Task["db:ensure_safe_target"].invoke
+    end
+  end
+
+  test "db:ensure_safe_target does not abort in non-test environments" do
+    Rails.application.load_tasks
+    Rake::Task["db:ensure_safe_target"].reenable
+    ClimateControl.modify RAILS_ENV: "development",
+                          POSTGRES_DB_PRODUCTION: "different_from_real_prod" do
+      Rake::Task["db:ensure_safe_target"].invoke
+    end
+  end
+
+  test "db:schema:load prerequisite chain includes the guard" do
+    Rails.application.load_tasks
+    Rake::Task["db:ensure_safe_target"].reenable
+    Rake::Task["db:schema:load"].reenable
+    ClimateControl.modify RAILS_ENV: "test" do
+      Rake::Task["db:schema:load"].invoke
+    end
+  end
+end

--- a/test/lib/tasks/db_safety_test.rb
+++ b/test/lib/tasks/db_safety_test.rb
@@ -3,37 +3,102 @@
 require "test_helper"
 
 class DbSafetyTaskTest < ActiveSupport::TestCase
-  test "db:ensure_safe_target passes when DB name matches _test pattern" do
-    Rails.application.load_tasks
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("db:ensure_safe_target")
+    Rake::Task["db:load_config"].invoke
     Rake::Task["db:ensure_safe_target"].reenable
-    ClimateControl.modify RAILS_ENV: "test" do
-      Rake::Task["db:ensure_safe_target"].invoke
+  end
+
+  test "allows an approved test database" do
+    assert_silent do
+      invoke_guard(env_name: "test", target_db: "sure_test")
     end
   end
 
-  test "db:ensure_safe_target is bypassed with ALLOW_PRODUCTION_DB_TASKS=1" do
-    Rails.application.load_tasks
-    Rake::Task["db:ensure_safe_target"].reenable
-    ClimateControl.modify ALLOW_PRODUCTION_DB_TASKS: "1" do
-      Rake::Task["db:ensure_safe_target"].invoke
+  test "rejects an unapproved test database" do
+    _, stderr = capture_io do
+      error = assert_raises(SystemExit) do
+        invoke_guard(env_name: "test", target_db: "sure_development")
+      end
+
+      assert_equal 1, error.status
+    end
+
+    assert_includes stderr, "'sure_development' is not an approved test database"
+  end
+
+  test "rejects a non-production environment targeting production" do
+    _, stderr = capture_io do
+      error = assert_raises(SystemExit) do
+        invoke_guard(
+          env_name: "development",
+          target_db: "sure_production",
+          production_db: "sure_production"
+        )
+      end
+
+      assert_equal 1, error.status
+    end
+
+    assert_includes stderr, "it points to the production database (sure_production)"
+  end
+
+  test "allows an explicit production database override" do
+    assert_silent do
+      invoke_guard(
+        env_name: "development",
+        target_db: "sure_production",
+        production_db: "sure_production",
+        allow_production: "1"
+      )
     end
   end
 
-  test "db:ensure_safe_target does not abort in non-test environments" do
-    Rails.application.load_tasks
-    Rake::Task["db:ensure_safe_target"].reenable
-    ClimateControl.modify RAILS_ENV: "development",
-                          POSTGRES_DB_PRODUCTION: "different_from_real_prod" do
-      Rake::Task["db:ensure_safe_target"].invoke
+  test "reports an invalid approved database pattern" do
+    _, stderr = capture_io do
+      error = assert_raises(SystemExit) do
+        invoke_guard(
+          env_name: "test",
+          target_db: "sure_test",
+          approved_pattern: "["
+        )
+      end
+
+      assert_equal 1, error.status
     end
+
+    assert_includes stderr, "APPROVED_TEST_DATABASES_PATTERN is invalid"
   end
 
   test "db:schema:load prerequisite chain includes the guard" do
-    Rails.application.load_tasks
-    Rake::Task["db:ensure_safe_target"].reenable
-    Rake::Task["db:schema:load"].reenable
-    ClimateControl.modify RAILS_ENV: "test" do
-      Rake::Task["db:schema:load"].invoke
-    end
+    guard_prerequisites = Rake::Task["db:ensure_safe_target"].prerequisites
+    schema_prerequisites = Rake::Task["db:schema:load"].prerequisites
+
+    assert_includes guard_prerequisites, "load_config"
+    assert_includes schema_prerequisites, "db:ensure_safe_target"
+    assert_operator schema_prerequisites.index("load_config"),
+                    :<,
+                    schema_prerequisites.index("db:ensure_safe_target")
   end
+
+  private
+
+    def invoke_guard(env_name:, target_db:, production_db: "permoney_production",
+                     approved_pattern: nil, allow_production: nil)
+      config = OpenStruct.new(database: target_db)
+      configurations = mock("database configurations")
+      configurations.stubs(:configs_for).with(env_name: env_name).returns([ config ])
+      ActiveRecord::Base.stubs(:configurations).returns(configurations)
+
+      ClimateControl.modify(
+        RAILS_ENV: env_name,
+        RACK_ENV: nil,
+        POSTGRES_DB: nil,
+        POSTGRES_DB_PRODUCTION: production_db,
+        APPROVED_TEST_DATABASES_PATTERN: approved_pattern,
+        ALLOW_PRODUCTION_DB_TASKS: allow_production
+      ) do
+        Rake::Task["db:ensure_safe_target"].invoke
+      end
+    end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # Force managed mode for tests (self-hosted guards disable subscriptions/invitations)
 ENV["SELF_HOSTED"] = "false"
 ENV["SELF_HOSTING_ENABLED"] = "false"
+ENV["OPENAI_ACCESS_TOKEN"] = "test-openai-token" if ENV["OPENAI_ACCESS_TOKEN"].to_s.empty?
 
 if ENV["COVERAGE"] == "true"
   require "simplecov"


### PR DESCRIPTION
## What
- Add `bin/test-db` for disposable PostgreSQL 18 test databases with local Docker lifecycle management and `--ci` support for external service containers
- Validate the resolved Rails adapter, host, port, and database before loading the schema
- Keep destructive database tasks behind `db:ensure_safe_target`; the harness no longer bypasses the guard
- Load Rails database configuration before evaluating safety and attach the guard through the public Rake prerequisite API
- Add regression coverage for approved/rejected database targets, production protection, invalid patterns, prerequisite ordering, and CI connection propagation
- Make AI-dependent controller tests deterministic when CI has no real OpenAI credential
- Add a PostgreSQL 18 GitHub Actions test job with an authenticated health check

## Verification
- Full suite with `OPENAI_ACCESS_TOKEN` empty through disposable PostgreSQL 18: 1,889 runs, 9,194 assertions, 0 failures, 0 errors, 19 skips
- `bin/test-db --ci -- bin/rails test test/lib/tasks/db_safety_test.rb test/bin/test_db_test.rb`: 7 runs, 33 assertions, 0 failures, 0 errors
- AI controller/model regression subset with no credential: 38 runs, 91 assertions, 0 failures, 0 errors
- `bin/rubocop -f github -a`
- `bin/brakeman --no-pager`: 0 security warnings
- `bin/rails zeitwerk:check`
- `bash -n bin/test-db`

No issue is linked to this infrastructure change.