### PR TITLE
Refresh agent instructions and add planning artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,5 @@ credentials.json
 # Catchup analysis (not for commit)
 docs/CATCHUP_SURE_COMMUNITY.md
 
-# Catchup analysis (not for commit)
-docs/CATCHUP_SURE_COMMUNITY.md
+# WIP issue specs (not ready to ship)
+issues/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,17 @@
   file so Codex, Claude Code, GitHub Copilot, and other agents follow the same
   engineering rules.
 
+  ### Companion Documents
+
+  - `CONTEXT.md` — canonical domain glossary (ubiquitous language). Use its terms
+    in code, tests, issues, and documentation. Do not introduce synonyms.
+  - `docs/adr/` — durable architectural decisions. Surface conflicts with existing
+    ADRs instead of silently overriding them.
+  - `docs/agents/` — agent harness, domain-doc rules, issue-tracker conventions,
+    and triage labels. Read `docs/agents/agent-harness.md` for the full execution
+    contract and feedback-loop commands.
+  - `DESIGN.md` — the authoritative design-system reference for all user-facing work.
+
   ### Serena Workflow
 
   - Activate the Sure project and read Serena's initial instructions at session start.
@@ -20,84 +31,50 @@
   ### Instruction Precedence
 
   1. User request and repository safety constraints.
-  2. This file and `DESIGN.md` for user-facing work.
-  3. Existing code patterns and tests.
-  4. Serena memories and historical documentation.
+  2. This file, `CONTEXT.md`, and `DESIGN.md` for user-facing work.
+  3. Relevant decisions under `docs/adr/`.
+  4. Existing code patterns and tests.
+  5. Serena memories and historical documentation.
 
-  # 🤖 AI Agents Documentation
+  ## ⚠️ CRITICAL: Development Philosophy
 
-  ## ⚠️ CRITICAL: Development Philosophy & Documentation Policy
+  ### Engineering Standard
 
-  ### 🚫 NO QUICK FIXES - ONLY PERMANENT SOLUTIONS
+  Every change must be **durable, grounded, and verified**.
 
-  **This project requires PROPER, COMPREHENSIVE, and PERMANENT solutions. NO shortcuts!**
+  **Durable** — Code must survive years of evolution. Design for
+  maintainability, adaptability, and clarity. Prefer deep domain
+  modeling over surface-level fixes. A proper permanent solution
+  always beats a fast temporary one.
 
-  #### Core Development Principles:
+  **Grounded** — Never guess at APIs, patterns, or behavior.
+  Use Context7, Firecrawl, or Exa MCP to verify current
+  documentation before writing code. Read existing code patterns
+  and `CONTEXT.md` vocabulary before introducing new ones.
+  When stuck on a bug, analyze the root cause — never disable
+  features, skip tests, or suggest workarounds.
 
-  1. **🎯 PRIORITY: Full latest ruby on rails Ecosystem + Shadcn/UI**
-     - ALWAYS use ruby on rails latest stable version
-     - ALWAYS use shadcn/ui latest stable version
-     - postgresql latest stable version
-     - redis latest stable version
-     - use latest stable versions of gems
-     - always upgrade if you find deprecated gems or anything to latest stable version
+  **Verified** — Every change must pass the full feedback loop
+  (see Pre-PR CI Workflow and `docs/agents/agent-harness.md`).
+  Work incrementally with small tested changes. Never leave
+  code in a broken state. If you cannot verify something works,
+  say so explicitly. Always use TDD workflow (`/tdd` skill) for
+  implementation work. For UI changes, record E2E verification
+  using Playwright or headless Chrome — screenshots or video —
+  before declaring work complete.
 
-  2. **🔍 ALWAYS USE FIRECRAWL, CONTEXT7 AND EXA MCP** - Use Firecrawl, exa, and Context7 MCP tool for up-to-date library documentation
-     - Get latest Ruby on Rails component documentation
-     - Get latest Shadcn/ui component documentation
-     - Verify API changes and best practices
-     - Never assume - always verify with official docs
-     - If need browsing use exa MCP
-
-  3. **🛠️ NO QUICK FIXES** - Every solution must be:
-     - ✅ **Proper**: Based on official Ruby on Rails & Shadcn/ui documentation
-     - ✅ **Comprehensive**: Addresses root cause, not just symptoms
-     - ✅ **Permanent**: Won't break in future or cause new issues
-     - ✅ **Well-analyzed**: Thoroughly investigated before implementation
-     - ✅ **Tested**: Verified to work correctly
-     - ❌ **NOT** a temporary workaround
-     - ❌ **NOT** a "quick fix" that creates technical debt
-     - **NOT** a Hardcoded - Always use Context7 MCP to verify ruby on rails/Shadcn and other stack in this project docs
-     -
-
-  4. **🐛 WHEN FACING BUGS**:
-     - ❌ **NEVER** disable features or tools when stuck
-     - ❌ **NEVER** give up or suggest "simple fixes"
-     - ✅ **ALWAYS** analyze the root cause thoroughly
-     - ✅ **ALWAYS** use Context7 MCP to verify ruby on rails/Shadcn and other stack in this project docs
-     - ✅ **ALWAYS** improve and optimize until bug is completely resolved
-     - ✅ **ALWAYS** be patient and work incrementally
-     - ✅ **ALWAYS** test thoroughly after each change
-
-  5. **📈 CONTINUOUS IMPROVEMENT**:
-     - Work incrementally with small, tested changes
-     - Each change should improve the codebase
-     - Never leave code in a broken state
-     - Always verify changes work before moving on
-     - Document complex logic with inline comments
-     - Leverage full ruby on rails ecosystem capabilities
-
-  6. **🎯 QUALITY OVER SPEED**:
-     - Take time to understand the problem deeply
-     - Research proper ruby on rails & Shadcn/ui solutions using Context7 and EXA MCP
-     - Implement carefully and test thoroughly
-     - A proper solution takes longer but saves time in the long run
-     - Use ruby on rails ecosystem to its full potential
-     - not hardcoded
-     - not workarounds
-     - not quick fixes
-     - not temporary solutions
-     - not "quick fixes" that create technical debt
-     - not "simple fixes" that don't improve the codebase
-     - not "temporary solutions" that don't improve the codebase
-     - not create simple version of something when you stuck on something you improve or fix must do PROPER and PERFECT way to achieve that
-
-
-  This document provides comprehensive guidance for AI agents working on the Sure codebase. It combines essential development patterns, architectural decisions, and best practices.
+  **Honest** — State what you know, what you assumed, and what
+  you could not verify. Flag uncertainty rather than presenting
+  guesses as facts. If a task exceeds your capability or context,
+  say so instead of producing plausible-looking but wrong output.
 
   ## Project Overview
 
-  Sure is a personal finance application built with Ruby on Rails that helps users track net worth, manage budgets, and gain financial insights. The application supports both managed hosting and self-hosted deployments.
+  Sure is a global personal finance product for a household to understand and
+  manage its shared financial life while preserving the financial practices of
+  the regions in which that household lives. See `CONTEXT.md` for canonical
+  domain language and `docs/adr/0012-global-core-with-regional-depth.md` for the
+  architectural framing.
 
   ### Application Modes
   - **Managed**: Sure team operates servers for users (`Rails.application.config.app_mode = "managed"`)
@@ -109,7 +86,8 @@
   - **Data**: `db/` (migrations, seeds), fixtures in `test/fixtures/`
   - **Tests**: `test/` mirroring `app/` structure (e.g., `test/models/*_test.rb`)
   - **Tooling**: `bin/` (project scripts), `docs/` (guides), `public/` (static), `lib/` (shared libs)
-  - **Components**: `app/components/` (ViewComponents with co-located Stimulus controllers)
+  - **Components**: `app/components/DS/` (Sure design system ViewComponents — the sole public component API per ADR-0008)
+  - **Planning**: `CONTEXT.md` (glossary), `docs/adr/` (decisions), `docs/agents/` (agent harness), `issues/` (issue specs)
 
   ## Core Domain Model
 
@@ -126,7 +104,9 @@
   **Assets**: Depository, Investment, Crypto, Property, Vehicle, Other Asset
   **Liabilities**: Credit Card, Loan (Person and Institute), Pay Later/BNPL, Personal Lending (borrowing), Other Liability
 
-  ### Indonesian Finance Features
+  ### Regional Coverage (Indonesia / Southeast Asia)
+  Indonesia and Southeast Asia are first-class markets, but country-specific
+  products must not leak into universal financial invariants (ADR-0012).
   - **Islamic Finance**: Sharia-compliant loans, credit cards, transaction types (Zakat, Infaq/Sadaqah)
   - **Personal Lending**: Qard Hasan, informal lending with tracking and reminders
   - **Fintech Integration**: Pinjol, P2P Lending, PayLater services
@@ -137,7 +117,7 @@
   - **Run app**: `bin/dev` — starts Rails server and asset/watchers via `Procfile.dev`
   - **Test suite**: `bin/rails test` — run all Minitest tests; add `TEST=test/models/user_test.rb` to target a file
   - **Lint Ruby**: `bin/rubocop` — style checks; add `-A` to auto-correct safe cops
-  - **Lint/format JS/CSS**: `npm run lint` and `npm run format` — uses Biome
+  - **Lint/format JS/CSS**: `pnpm run lint` and `pnpm run format` — uses Biome
   - **Security scan**: `bin/brakeman` — static analysis for common Rails issues
 
   ### Isolated Test DB (Docker, never touch production DB/volumes)
@@ -175,11 +155,17 @@
 
   ### Pre-Pull Request CI Workflow
   **ALWAYS run these commands before opening a pull request:**
-  1. **Tests** (Required): `bin/rails test` — Run all tests (always required)
-  2. **Linting** (Required): `bin/rubocop -f github -a` — Ruby linting with auto-correct
-  3. **Security** (Required): `bin/brakeman --no-pager` — Security analysis
+  1. `bin/rails zeitwerk:check` — Autoload verification
+  2. `bin/rubocop -f github` — Ruby linting
+  3. `pnpm install --frozen-lockfile && pnpm run lint` — JS linting
+  4. `bin/brakeman --no-pager` — Security analysis
+  5. `bin/importmap audit` — JS dependency audit
+  6. `RAILS_ENV=test bin/rails db:schema:load && bin/rails test` — Full test suite (every test, no skips)
+  7. For UI changes: record E2E verification via Playwright or headless Chrome (screenshot or video)
 
-  Only proceed with pull request creation if ALL checks pass.
+  Only proceed with pull request creation if ALL checks pass. "All tests pass"
+  means you ran the entire suite and can show the output — never claim green
+  without actually running it.
 
   ## General Development Rules
 
@@ -211,8 +197,8 @@
     - We pin `@hotwired/stimulus-loading` to a local shim at `app/javascript/stimulus-loading.js` via `config/importmap.rb`
     - Custom loading uses `Promise.all` for proper async controller registration
     - `app/javascript/controllers/index.js` eager‑loads controllers with `await` to ensure all controllers load before app initialization
-    - **ALL controllers MUST be in `app/javascript/controllers/`** - subdirectories like `controllers/shadcn/` and `controllers/DS/` are supported
-    - Controllers are registered with hyphenated identifiers: `shadcn/tabs_controller.js` → `shadcn--tabs`
+    - **ALL controllers MUST be in `app/javascript/controllers/`** — subdirectory `controllers/DS/` is supported
+    - Controllers are registered with hyphenated identifiers: `DS/tabs_controller.js` → `ds--tabs`
   - **After adding controllers or vendor JS**, restart `bin/dev` and consider `bin/rails tmp:cache:clear` if digests look stale
 
   ## TailwindCSS Design System
@@ -229,21 +215,18 @@
 
   ## Component Architecture
 
+  `DS::*` is the sole public component API (ADR-0008). Do not add components
+  outside the `DS::` namespace.
+
   ### ViewComponent vs Partials Decision Making
-  **Use ViewComponents when:**
-  - Element has complex logic or styling patterns
+  **Use DS:: ViewComponents when:**
+  - Element has complex logic, styling variants, or interactive behavior
   - Element will be reused across multiple views/contexts
-  - Element needs structured styling with variants/sizes
-  - Element requires interactive behavior or Stimulus controllers
-  - Element has configurable slots or complex APIs
   - Element needs accessibility features or ARIA support
 
   **Use Partials when:**
   - Element is primarily static HTML with minimal logic
   - Element is used in only one or few specific contexts
-  - Element is simple template content
-  - Element doesn't need variants, sizes, or complex configuration
-  - Element is more about content organization than reusable functionality
 
   ### Stimulus Controller Guidelines
   **Declarative Actions (Required):**
@@ -260,7 +243,7 @@
   - Use private methods and expose clear public API
   - Single responsibility or highly related responsibilities
   - **CRITICAL**: ALL Stimulus controllers MUST be in `app/javascript/controllers/` (Rails 8.1 requirement)
-  - Subdirectories are allowed: `app/javascript/controllers/shadcn/`, `app/javascript/controllers/DS/`
+  - Subdirectory `app/javascript/controllers/DS/` is used for design-system controllers
   - Pass data via `data-*-value` attributes, not inline JavaScript
   - Avoid `event.stopPropagation()` - let events bubble for Turbo navigation
 
@@ -316,11 +299,14 @@
   ## Background Processing
 
   Sidekiq handles asynchronous tasks:
-  - **Account syncing** (`SyncAccountsJob`)
-  - **Import processing** (`ImportDataJob`)
-  - **AI chat responses** (`CreateChatResponseJob`)
-  - **Scheduled maintenance** via sidekiq-cron
-  - **Market data imports** (`ImportMarketDataJob`)
+  - **Account syncing** (`SyncJob`, `SyncAllAccountsJob`, `SyncCleanupJob`)
+  - **Import processing** (`ImportJob`, `ImportMarketDataJob`)
+  - **AI chat responses** (`StreamingAssistantResponseJob`)
+  - **Scheduled maintenance** via sidekiq-cron (`config/schedule.yml`)
+  - **Recurring intelligence** (`RecurringIntelligenceJob`)
+  - **Subscription lifecycle** (`SubscriptionRenewalJob`)
+  - **Regional data** (`GoldPriceFetchJob`, `GoldAutoRevaluationJob`)
+  - **Monitoring** (`MemoryMonitoringJob`, `DatabasePoolMonitoringJob`, `CacheMonitoringJob`)
 
   ### Job Configuration
   - **Queues**: `scheduled`, `high_priority`, `medium_priority`, `low_priority`, `default`
@@ -440,60 +426,9 @@
   // });
   ```
 
-  ### Rails 8.1 Upgrade Issues & Fixes (October 31, 2025)
-
-  **Issue 1: Stimulus Controllers Not Loading from Subdirectories**
-  - **Problem**: Controllers in `app/components/shadcn/` and `app/components/DS/` were not being loaded by Importmap
-  - **Root Cause**: `pin_all_from "app/components"` was ineffective for nested directories
-  - **Solution**:
-    - Moved all Stimulus controllers to `app/javascript/controllers/` following Rails conventions
-    - Fixed async loading in `app/javascript/stimulus-loading.js` with `Promise.all` and `await`
-    - Updated `app/javascript/controllers/index.js` to properly await controller loading
-  - **Files Changed**:
-    - `config/importmap.rb`: Removed incorrect pin_all_from
-    - `app/javascript/stimulus-loading.js`: Fixed async controller registration
-    - `app/javascript/controllers/index.js`: Added await for eager loading
-    - Moved controllers from `app/components/` to `app/javascript/controllers/`
-
-  **Issue 2: Event Propagation Blocking Clicks**
-  - **Problem**: `event.stopPropagation()` in multiple controllers blocked event bubbling
-  - **Root Cause**: Overly aggressive event handling prevented Turbo navigation
-  - **Solution**: Removed `stopPropagation()` from tab and menu controllers, keeping only `preventDefault()` where needed
-  - **Files Changed**:
-    - `app/javascript/controllers/shadcn/tabs_controller.js`
-    - `app/javascript/controllers/DS/tabs_controller.js`
-    - `app/javascript/application.js`: Removed problematic `turbo:click` handler
-
-  **Issue 3: Dropdown Menu Items Not Navigating**
-  - **Problem**: Menu items inside Turbo Frame couldn't navigate to full pages
-  - **Root Cause**: User menu wrapped in `turbo_frame_tag` caused Turbo to load responses inside frame instead of full page navigation
-  - **Solution**: Added `data-turbo-frame="_top"` to menu link items to break out of parent frames
-  - **Files Changed**:
-    - `app/components/DS/menu_item.rb`: Added automatic `_top` frame for link items
-    - `app/javascript/controllers/DS/menu_controller.js`: Added `turbo:before-visit` handler for clean menu close
-
-  **Issue 4: ActiveSupport::Configurable Deprecation Flood**
-  - **Problem**: Rails 8.1 logs a warning every time `ActiveSupport::Configurable` autoloads (removed in 8.2)
-  - **Root Cause**: Dependencies (ViewComponent, OmniAuth helpers, etc.) still reference the deprecated module
-  - **Solution**: Provide our own drop-in implementation at `lib/active_support/configurable.rb` using `class_attribute` + `ActiveSupport::InheritableOptions`, and load it before `Bundler.require`
-  - **Files Changed**:
-    - `config/boot.rb`: Adds `lib` to `$LOAD_PATH` so our shim wins `require "active_support/configurable"`
-    - `config/application.rb`: Requires the shim before other gems boot
-    - `lib/active_support/configurable.rb`: Shim implementation maintained until upstream gems remove the dependency
-
-  **Issue 5: connection_pool 3.x keyword-only API + Sidekiq positional calls**
-  - **Problem**: connection_pool 3.x initializer and `TimedStack#pop` are keyword-only; Sidekiq and legacy code still pass positional args (e.g., `ConnectionPool.new(5)` or `TimedStack#pop(10)`), leading to stack overflows or `ArgumentError` in production.
-  - **Solution**: Early boot shim in `config/boot.rb`:
-    - Guarded (`@__Sure_patched`) to avoid re-alias recursion.
-    - Normalizes positional/Hash args to keywords before delegating to the original initializer via `bind_call`.
-    - Patches `ConnectionPool::TimedStack#pop` to map positional timeout to keyword `timeout`.
-  - **Upgrade note**: Keep this shim until Sidekiq/Redis clients are fully keyword-safe; revisit after upgrading connection_pool/Sidekiq to versions that no longer use positional APIs.
-
-  **Key Learnings:**
-  - Rails 8.1 requires stricter Stimulus controller location conventions
-  - Turbo Frames need explicit `_top` target to break out for full page navigation
-  - Event handling must allow proper bubbling for Turbo to work correctly
-  - Async controller loading must use `Promise.all` to ensure all controllers are registered
+  ### Rails 8.1 Upgrade Shims (still active)
+  - **ActiveSupport::Configurable shim** (`lib/active_support/configurable.rb`): Suppresses deprecation flood from ViewComponent/OmniAuth until upstream gems drop the dependency. Loaded early in `config/boot.rb`.
+  - **connection_pool 3.x shim** (`config/boot.rb`): Normalizes positional args to keywords for Sidekiq/Redis. Keep until Sidekiq is fully keyword-safe.
 
   ### Rails 8 Breaking Changes (from 7.x)
   - **RedisCacheStore Configuration**: Connection pool parameters changed from `pool_size:` and `pool_timeout:` to nested `pool: { size:, timeout: }` format
@@ -503,18 +438,19 @@
   ### Stack Components
   - **Backend**: Ruby on Rails 8.1.3
   - **Database**: PostgreSQL 18.x with UUID primary keys
-  - **Frontend**: Hotwire (Turbo 2.0.17 + Stimulus 3.x)
-  - **Styling**: TailwindCSS v4 with custom design system
-  - **Linting**: Biome 2.2.6 (JavaScript/TypeScript)
+  - **Frontend**: Hotwire (Turbo 2.0.23 + Stimulus 3.x)
+  - **Styling**: TailwindCSS v4 with Sure design system (`DS::*`, see `DESIGN.md`)
+  - **Linting**: Biome 2.4.16 (JavaScript/TypeScript), RuboCop (Ruby), Brakeman 8.0.5 (security)
   - **Testing**: Minitest + fixtures
-  - **Jobs**: Sidekiq + Redis 7.4.x
-  - **External APIs**: Plaid, OpenAI, Stripe
+  - **Jobs**: Sidekiq 8.1.6 + Redis 7.4.x
+  - **External APIs**: Plaid, OpenAI, Stripe 19.2.0
   - **Deployment**: Docker support for self-hosting
+  - **Package manager (JS)**: pnpm (not npm/yarn)
 
   ### Key Dependencies
-  - **aws-sdk-s3**: 1.200.0 (IMDSv2 support)
-  - **rubyzip**: 3.2 (enhanced security)
-  - **@biomejs/biome**: 2.2.6 (migrated from 1.9.4)
+  - **aws-sdk-s3**: 1.224.0 (IMDSv2 support)
+  - **rubyzip**: 3.2.2
+  - **@biomejs/biome**: 2.4.16
 
   ### Upgrade Policy
   - Always use latest stable versions
@@ -596,109 +532,12 @@
   - **Background Job Tracking**: Queue depths, slow jobs
 
   ### Performance Guidelines
-
-  **Database Queries:**
-  ```ruby
-  # ❌ AVOID: N+1 queries
-  @accounts.each { |a| a.entries.count }
-
-  # ✅ USE: Eager loading
-  @accounts = Account.includes(:entries)
-
-  # ✅ USE: Counter caches
-  @accounts.each { |a| a.entries_count }
-
-  # ✅ USE: Efficient loading concern
-  @accounts = Account.for_list.with_common_associations
-  ```
-
-  **Caching:**
-  ```ruby
-  # ✅ USE: Fragment caching for expensive operations
-  Rails.cache.fetch("key", expires_in: 1.hour) do
-    expensive_calculation
-  end
-
-  # ✅ USE: Model-level caching helpers
-  Account.fetch_cached("balance_series") do
-    calculate_balance_series
-  end
-  ```
-
-  **Background Jobs:**
-  ```ruby
-  # ❌ AVOID: Inline processing of slow operations
-  def create
-    @account.sync_transactions  # Slow!
-  end
-
-  # ✅ USE: Background jobs
-  def create
-    SyncAccountJob.perform_later(@account.id)
-  end
-
-  # ✅ USE: Batch processing
-  Account.in_efficient_batches(batch_size: 1000) do |account|
-    process(account)
-  end
-  ```
-
-  **Memory Management:**
-  ```ruby
-  # ❌ AVOID: Loading all records
-  Account.all.each { |a| process(a) }
-
-  # ✅ USE: Batch iteration
-  Account.find_each(batch_size: 1000) { |a| process(a) }
-
-  # ✅ USE: Pluck for simple data
-  Account.pluck(:id)  # Not Account.all.map(&:id)
-  ```
-
-  ### Performance Monitoring
-
-  **Key Metrics:**
-  - Response time: Target <200ms p95
-  - Throughput: Requests per second
-  - Memory usage: Per process
-  - Database pool: Connection usage
-  - Cache hit rate: Target >80%
-  - Background jobs: Queue depths
-
-  **Monitoring Tools:**
-  - Sentry: Performance traces, errors, custom metrics
-  - Sidekiq Dashboard: `/sidekiq` for job monitoring
-  - Rails logs: Query logs, cache logs
-  - PostgreSQL: Slow query logs
-
-  ### Performance Testing
-
-  ```bash
-  # Load testing
-  hey -n 1000 -c 50 http://localhost:3000/accounts
-
-  # Benchmarking
-  bundle exec derailed bundle:mem
-  bundle exec derailed exec perf:test
-  ```
-
-  ### Configuration Files
-
-  - `.env.local.example`: All performance environment variables
-  - `config/puma.rb`: Application server configuration
-  - `config/sidekiq.yml`: Background job configuration
-  - `config/database.yml`: Database connection pooling
-  - `config/environments/production.rb`: Redis cache store
-  - `config/initializers/sentry.rb`: Comprehensive monitoring
-  - `docs/PERFORMANCE_GUIDE.md`: Complete performance documentation
-
-  ### Expected Results
-
-  - **Response Time**: 50-70% reduction
-  - **Throughput**: 3-5x increase
-  - **Memory Usage**: 30-40% reduction
-  - **Database Load**: 40-60% reduction
-  - **Background Jobs**: 3-5x faster processing
+  - Use `includes` / `preload` to avoid N+1 queries; use `pluck` for simple data
+  - Use `find_each` / `in_batches` instead of `Account.all.each`
+  - Use `Rails.cache.fetch` with TTL for expensive calculations
+  - Move slow operations to background jobs (`perform_later`)
+  - Target <200ms p95 response time, >80% cache hit rate
+  - Monitor via Sentry APM, Sidekiq Dashboard (`/sidekiq`), PostgreSQL slow query logs
 
   ## Security Best Practices (Rails 8.1)
 
@@ -869,70 +708,6 @@
   }
   ```
 
-  ## Common Patterns
-
-  ### Account Balance Calculation
-  ```ruby
-  # Daily balances calculated from entries
-  account.balances.order(:date)
-
-  # Current balance
-  account.current_balance
-
-  # Balance on specific date
-  account.balance_on(date)
-  ```
-
-  ### Entry Management
-  ```ruby
-  # Create transaction
-  account.transactions.create!(
-    amount: -100, # Negative for expense
-    currency: "USD",
-    date: Date.current
-  )
-
-  # Create transfer
-  Transfer.create!(
-    from_account: checking,
-    to_account: savings,
-    amount: 500
-  )
-  ```
-
-  ### Family Management
-  ```ruby
-  # Current family context
-  Current.family
-
-  # Family members
-  family.users
-
-  # Family accounts
-  family.accounts
-  ```
-
-  ### Indonesian Finance Examples
-  ```ruby
-  # Islamic finance transaction
-  transaction.update!(kind: "zakat_payment", is_sharia_compliant: true)
-
-  # Personal lending
-  personal_lending = PersonalLending.create!(
-    counterparty_name: "Ahmad",
-    lending_direction: "lending_out",
-    lending_type: "qard_hasan",
-    relationship: "friend"
-  )
-
-  # Pinjol loan
-  loan = Loan.create!(
-    compliance_type: "conventional",
-    fintech_type: "pinjol",
-    counterparty_name: "Kredivo"
-  )
-  ```
-
   ## Documentation Guidelines
 
   ### ⚠️ CRITICAL: NO NEW DOCUMENTATION FILES
@@ -993,7 +768,7 @@
 
   ### Views & Components
   - `app/views/layouts/application.html.erb`: Main layout
-  - `app/components/`: ViewComponents (prefer over partials)
+  - `app/components/DS/`: Sure design system ViewComponents (sole public component API)
   - `app/helpers/application_helper.rb`: Global helpers (icon helper)
 
   ### Assets
@@ -1011,21 +786,18 @@
 
   When working on this codebase:
 
-  1. **Always check existing patterns** before implementing new features
-  2. **Use the design system** (`app/assets/tailwind/Sure-design-system.css`) for styling
-  3. **Follow Rails conventions** for file organization
-  4. **Write tests** for new functionality using Minitest + fixtures
-  5. **Update documentation** when adding features (update existing files, don't create new ones)
-  6. **Consider both managed and self-hosted modes** in your implementations
-  7. **Respect the AGPLv3 license** and attribution requirements
-  8. **Use `Current.user` and `Current.family`** instead of `current_user`/`current_family`
-  9. **Prioritize Indonesian finance features** when relevant (Islamic finance, personal lending, local categories)
-  10. **Always use `icon` helper** instead of `lucide_icon` directly
-  11. **Keep controllers skinny** - business logic belongs in models
-  12. **Use ViewComponents** for complex UI, partials for simple content
-  13. **Prefer semantic HTML** over custom JavaScript components
-  14. **Test critical paths only** - don't test ActiveRecord functionality
-  15. **Run pre-PR checks**: tests, linting, security scan
+  1. **Read `CONTEXT.md`** for canonical domain vocabulary before writing code
+  2. **Use `DS::*` components and `DESIGN.md`** for all UI work
+  3. **Use `Current.user` and `Current.family`** — never `current_user`/`current_family`
+  4. **Always use `icon` helper** in `application_helper.rb` — never `lucide_icon` directly
+  5. **Keep controllers skinny** — business logic belongs in models
+  6. **Global core, regional depth** — country-specific products must not leak into universal invariants
+  7. **Consider both managed and self-hosted modes** in implementations
+  8. **Always use TDD** — invoke `/tdd` skill for every implementation task
+  9. **Run the full feedback loop** before declaring work complete (see Pre-PR CI Workflow) — show actual test output, never claim passing without running
+  10. **Record UI verification** — use Playwright or headless Chrome for E2E evidence on UI changes
+  11. **Use pnpm** as the JavaScript package manager — not npm or yarn
+  12. **Product identity is Sure** — do not introduce other product names (ADR-0002)
 
   ### Quick Reference Commands
   ```bash
@@ -1033,10 +805,13 @@
   cp .env.local.example .env.local && bin/setup
   bin/dev
 
-  # Testing and quality
-  bin/rails test
-  bin/rubocop -f github -a
+  # Full feedback loop (run before PRs)
+  bin/rails zeitwerk:check
+  bin/rubocop -f github
+  pnpm install --frozen-lockfile && pnpm run lint
   bin/brakeman --no-pager
+  bin/importmap audit
+  RAILS_ENV=test bin/rails test
 
   # Debugging
   bin/rails console

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,280 @@
+# Sure
+
+Sure is a global personal finance product for a household to understand and
+manage its shared financial life while preserving the financial practices of
+the regions in which that household lives.
+
+## Product Scope
+
+**Global Financial Core**:
+The country-neutral financial concepts and invariants shared by every Family,
+regardless of locale or provider.
+_Avoid_: Western default, Indonesian default
+
+**Regional Financial Practice**:
+A financial product, convention, institution, or workflow used in a particular
+market and expressed through the Global Financial Core.
+_Avoid_: Global default, special-case product architecture
+
+**Regional Coverage**:
+The explicit languages, currencies, providers, terminology, examples, and
+financial practices supported for a region. Indonesia and Southeast Asia are
+first-class Regional Coverage, not the universal default.
+_Avoid_: Country fork, translation only
+
+## Household
+
+**Family**:
+The authoritative household boundary that owns the shared financial record and
+determines which financial facts belong together.
+_Avoid_: Tenant, workspace, organization, account
+
+**User**:
+A person who belongs to a Family and acts within the permissions granted to
+them. A User is not the owner boundary of the shared financial record.
+_Avoid_: Account, customer, tenant
+
+**Family Member**:
+A User who can view and manage the complete shared financial record of their
+Family but cannot administer Family membership, integrations, security,
+billing, or household-wide settings.
+_Avoid_: Read-only user, account guest
+
+**Family Admin**:
+A User who can manage the shared financial record and administer membership,
+integrations, security, billing, and household-wide settings for their Family.
+_Avoid_: Owner, tenant admin, super admin
+
+## Recurring Finance
+
+**Recurring Hub**:
+The user-facing area where a Family reviews recurring financial activity,
+including Recurring Patterns and Subscriptions.
+_Avoid_: Subscription Manager
+
+**Recurring Pattern**:
+A repeated transaction, income event, or transfer pattern that Sure detects or
+a Family confirms.
+_Avoid_: Subscription, recurring transaction
+
+**Subscription**:
+A Family's continuing paid commitment to a Service.
+_Avoid_: Recurring Pattern, Sure Membership, plan
+
+**Renewal**:
+One billing or payment cycle of a Subscription.
+_Avoid_: Subscription, recurring transaction
+
+**Service**:
+A catalog identity for an organization or utility that may provide a
+Subscription; it is not itself part of a Family's financial record.
+_Avoid_: Merchant, Subscription
+
+**Sure Membership**:
+A Family's entitlement to managed Sure product services.
+_Avoid_: Subscription, Subscription Plan
+
+**Application Mode**:
+The operational environment in which Sure runs, either Managed or Self Hosted;
+it does not change the meaning of a Family's financial record.
+_Avoid_: Pricing plan, financial feature tier
+
+## Financial Record
+
+**Entry**:
+A dated financial fact recorded against an Account, such as a Transaction,
+Valuation, or Trade.
+_Avoid_: Balance, activity row
+
+**Transaction**:
+A dated flow of value between a Family Account and an external party.
+_Avoid_: Transfer, Valuation
+
+**Transfer**:
+A movement of value between two Accounts in the same Family that is neither
+income nor expense.
+_Avoid_: Transaction, income, expense
+
+**Inflow**:
+Value entering an Account.
+_Avoid_: Negative amount
+
+**Outflow**:
+Value leaving an Account.
+_Avoid_: Positive amount
+
+**Balance Anchor**:
+An Account balance that was directly observed or explicitly confirmed for a
+specific date.
+_Avoid_: Balance Snapshot, current balance
+
+**Balance Snapshot**:
+A derived daily Account balance that can be rebuilt from financial facts and
+anchors.
+_Avoid_: Balance Anchor, ledger entry
+
+**Current Balance**:
+The latest projected Account balance used for present-day display.
+_Avoid_: Historical source of truth, Balance Anchor
+
+**Holding Snapshot**:
+An observed investment position at a specific date, whether or not complete
+Trade history is available.
+_Avoid_: Trade, security transaction
+
+**Trade**:
+A dated investment activity that changes or describes an investment position;
+it is not necessarily a complete history of that position.
+_Avoid_: Holding Snapshot, Transaction
+
+**Reconciliation**:
+An explicit, auditable alignment between calculated financial state and an
+observed state.
+_Avoid_: Silent correction, history rewrite
+
+**Data Provenance**:
+The origin and identity of a financial fact, including its source, external
+identity when present, effective time, and observation time.
+_Avoid_: Audit Log, sync status
+
+**Review Item**:
+An unresolved conflict or ambiguity that could materially change a Family's
+financial record and requires an explicit decision.
+_Avoid_: Validation error, notification
+
+**Enrichment**:
+Derived descriptive information, such as normalized merchants or suggested
+categories, that does not replace the underlying financial fact.
+_Avoid_: Source data, manual correction
+
+## AI
+
+**AI Processing**:
+An explicitly enabled use of an external or self-hosted model to analyze selected
+Family information for a stated purpose.
+_Avoid_: Anonymous processing, automatic consent
+
+**AI Suggestion**:
+AI-generated advice or Enrichment that does not change a material financial fact
+until a User explicitly confirms it.
+_Avoid_: Financial fact, automatic correction
+
+**AI Provider**:
+The configured model service that performs AI Processing under a disclosed data
+and retention policy.
+_Avoid_: Model, assistant
+
+**Reporting Currency**:
+The currency a Family chooses for aggregated reports and presentation; it does
+not replace the original currency of a financial fact.
+_Avoid_: Base storage currency, Account currency
+
+**Exchange Rate Observation**:
+An observed conversion rate between two currencies for a specific effective
+date.
+_Avoid_: Current rate, implicit fallback
+
+## Assets And Debts
+
+**Account**:
+A record of one financial position held by or owed by a Family.
+_Avoid_: User, login, provider connection
+
+**Asset**:
+A resource with economic value controlled by a Family.
+_Avoid_: Available credit, income
+
+**Liability**:
+A present obligation of a Family to another party.
+_Avoid_: Expense, credit limit
+
+**Receivable**:
+An Asset representing money owed to a Family.
+_Avoid_: Personal debt, borrowed money
+
+**Debt Agreement**:
+A Liability representing principal and repayment obligations owed by a Family
+to a lender or financier.
+_Avoid_: Receivable, Personal Lending
+
+**Secured Debt**:
+A Debt Agreement backed by Collateral.
+_Avoid_: Mortgage, secured asset
+
+**Collateral**:
+An Asset pledged to secure a Debt Agreement.
+_Avoid_: Debt, installment
+
+**Mortgage**:
+A Secured Debt whose Collateral is Property.
+_Avoid_: Property, rent
+
+**Vehicle Financing**:
+A Secured Debt whose Collateral is a Vehicle.
+_Avoid_: Vehicle, lease payment
+
+**Consumer Financing**:
+A Debt Agreement used to acquire a consumer good without a reusable revolving
+credit facility.
+_Avoid_: PayLater, Subscription
+
+**PayLater**:
+A reusable buy-now-pay-later credit facility whose utilized amount is a
+Liability; its credit limit and available credit are not Assets.
+_Avoid_: Consumer Financing, Asset
+
+**Personal Lending**:
+A Receivable created when a Family lends money to another person.
+_Avoid_: Borrowing, Debt Agreement
+
+**Installment Schedule**:
+The planned sequence of payments for a Debt Agreement.
+_Avoid_: Payment history, Subscription schedule
+
+**Installment**:
+One scheduled payment obligation within an Installment Schedule.
+_Avoid_: Transaction, Renewal
+
+**Principal Payment**:
+The portion of a Debt Agreement payment that reduces principal and transfers
+value from cash to reduce a Liability.
+_Avoid_: Expense, interest
+
+**Financing Cost**:
+Interest, margin, or fees paid for a Debt Agreement and recognized as expense.
+_Avoid_: Principal Payment
+
+**Financing Structure**:
+The contractual method used by a Debt Agreement, including conventional and
+Sharia-compliant structures such as Murabaha or Ijarah.
+_Avoid_: Account type, Debt classification
+
+## Precious Metals
+
+**Precious Metal**:
+A physical or custodial metal asset measured by quantity and unit. Gold is one
+kind of Precious Metal.
+_Avoid_: Gold account, Security
+
+**Precious Metal Position**:
+The quantity of a Precious Metal held by a Family.
+_Avoid_: Balance, Valuation
+
+**Metal Activity**:
+A dated purchase, sale, fee, or quantity adjustment affecting a Precious Metal
+Position.
+_Avoid_: Trade, Valuation
+
+**Quantity Anchor**:
+A Precious Metal quantity directly observed or explicitly confirmed for a
+specific date.
+_Avoid_: Metal Activity, Current Balance
+
+**Market Price Observation**:
+An observed price per unit of an asset in a stated currency on a specific date.
+_Avoid_: Valuation, purchase price
+
+**Metal Valuation**:
+The derived monetary value of a Precious Metal Position using a Market Price
+Observation and any required currency conversion.
+_Avoid_: Purchase cost, Metal Activity

--- a/docs/adr/0001-foundation-before-feature-catchup.md
+++ b/docs/adr/0001-foundation-before-feature-catchup.md
@@ -1,0 +1,7 @@
+# Stabilize the foundation before major feature catch-up
+
+Sure will continue monitoring upstream community activity and may fix critical
+defects, but it will not adopt major features until the test suite, CI quality
+gates, Sure product identity, agent documentation, and design-system enforcement
+have a reliable green baseline. This trades short-term feature velocity for an
+AFK-capable development foundation that can safely sustain faster catch-up work.

--- a/docs/adr/0002-sure-product-identity.md
+++ b/docs/adr/0002-sure-product-identity.md
@@ -1,0 +1,7 @@
+# Use Sure as the sole product identity
+
+Sure is the only product name used in the interface, runtime configuration,
+database defaults, operational documentation, and code comments. References to
+Permoney must be removed; references to Maybe Finance may remain only where
+legal attribution, licensing, or accurate repository history requires them, so
+the project's origin remains compliant without presenting Maybe as the product.

--- a/docs/adr/0003-ai-as-a-workspace.md
+++ b/docs/adr/0003-ai-as-a-workspace.md
@@ -1,0 +1,8 @@
+# Present AI as a dedicated workspace
+
+Sure exposes AI conversations through a dedicated chat workspace reached from
+the primary navigation, not through a globally rendered floating overlay.
+Contextual AI actions may appear on relevant screens through the canonical
+design system, but a universal floating trigger is rejected because it competes
+with financial workflows, duplicates navigation, and creates persistent design
+drift.

--- a/docs/adr/0004-provenance-without-event-sourcing.md
+++ b/docs/adr/0004-provenance-without-event-sourcing.md
@@ -1,0 +1,8 @@
+# Add financial provenance without adopting full event sourcing
+
+Sure will make provenance, idempotency, reconciliation, and material financial
+audits explicit at its highest-value financial boundaries, while retaining the
+current relational model. Full event sourcing is rejected during foundation
+stabilization because its migration cost and operational complexity would delay
+correctness work; rebuildable snapshots and targeted versioning provide the
+needed integrity without a wholesale rewrite.

--- a/docs/adr/0005-blocking-quality-gates.md
+++ b/docs/adr/0005-blocking-quality-gates.md
@@ -1,0 +1,8 @@
+# Require blocking quality gates for AFK-ready work
+
+An issue may be marked ready for an AFK agent only when its completion can be
+verified by blocking CI gates: schema load and the full Minitest suite on
+disposable PostgreSQL 18, Zeitwerk validation, RuboCop, Biome installed through
+the frozen pnpm lockfile, Brakeman, and Importmap audit. Managed and self-hosted
+smoke coverage plus a small set of critical system journeys are required; static
+typing is deferred until the untyped baseline is reliable.

--- a/docs/adr/0006-evaluate-upstream-dont-chase-parity.md
+++ b/docs/adr/0006-evaluate-upstream-dont-chase-parity.md
@@ -1,0 +1,7 @@
+# Evaluate upstream changes instead of chasing parity
+
+The active `we-promise/sure` community repository is a source of evidence and
+ideas, not an automatic backlog. Each upstream change is classified as Adopt,
+Adapt, Reject, Already Ahead, or Investigate based on Sure's domain contracts,
+design system, local capabilities, and foundation gate; commit, migration, or
+file-count parity is not treated as a quality target.

--- a/docs/adr/0007-one-financial-product-across-modes.md
+++ b/docs/adr/0007-one-financial-product-across-modes.md
@@ -1,0 +1,7 @@
+# Keep one financial product across managed and self-hosted modes
+
+Managed and Self Hosted deployments share the same financial domain, core user
+experience, and data semantics. Differences are restricted to explicit platform
+capabilities and policies such as Sure Membership billing, email delivery,
+telemetry, support impersonation, and provider administration, avoiding two
+divergent products hidden behind deployment mode checks.

--- a/docs/adr/0008-one-sure-design-system.md
+++ b/docs/adr/0008-one-sure-design-system.md
@@ -1,0 +1,7 @@
+# Use one Sure design system
+
+`DS::*`, backed by the tokens and principles in `DESIGN.md`, is the only public
+component API for Sure's interface. The parallel shadcn namespace and styling
+will be removed after its consumers migrate; accessible interaction patterns
+and WAI-ARIA guidance remain valid engineering references, but shadcn is not a
+second product design system.

--- a/docs/adr/0009-preserve-original-currencies.md
+++ b/docs/adr/0009-preserve-original-currencies.md
@@ -1,0 +1,7 @@
+# Preserve original currencies and convert only for reporting
+
+Financial facts and observations retain their original currencies, while a
+Family's currency is used only as the Reporting Currency for presentation and
+aggregation. Historical conversion uses dated Exchange Rate Observations and
+must surface missing rates instead of silently substituting `1`; changing the
+Reporting Currency never rewrites financial history.

--- a/docs/adr/0010-model-economic-substance-of-money-flows.md
+++ b/docs/adr/0010-model-economic-substance-of-money-flows.md
@@ -1,0 +1,8 @@
+# Model the economic substance of money flows
+
+Sure distinguishes external Transactions from internal Transfers and decomposes
+debt payments into principal and Financing Cost. Principal repayment, credit
+payments, loan disbursement, and Personal Lending movements must not be reported
+as income or expense merely because cash moved; reports and budgets follow the
+underlying economic change while UI and APIs express inflow/outflow without
+exposing internal sign conventions.

--- a/docs/adr/0011-explicit-ai-data-governance.md
+++ b/docs/adr/0011-explicit-ai-data-governance.md
@@ -1,0 +1,8 @@
+# Require explicit governance for AI processing
+
+AI Processing is opt-in, provider-agnostic, and limited to the minimum data
+needed for a disclosed purpose. Family Admins configure providers and Family
+automation, individual Users consent to private chat use, prompts and financial
+payloads are excluded from telemetry by default, document indexing is explicit
+and deletable, and AI output remains an AI Suggestion until a User confirms any
+material financial change.

--- a/docs/adr/0012-global-core-with-regional-depth.md
+++ b/docs/adr/0012-global-core-with-regional-depth.md
@@ -1,0 +1,8 @@
+# Build a global core with regional depth
+
+Sure models country-neutral financial concepts and invariants at its core while
+supporting regional products, terminology, providers, and practices through
+explicit Regional Coverage. Indonesia and Southeast Asia remain first-class
+markets, including Islamic finance, PayLater, cooperative and informal lending,
+local utilities, and local currencies, but no country is treated as the default
+shape of every Family's financial life.

--- a/docs/agents/agent-harness.md
+++ b/docs/agents/agent-harness.md
@@ -1,0 +1,100 @@
+# Sure Agent Harness
+
+This document defines the portable execution contract for engineering agents
+working on Sure.
+
+## Authority
+
+Apply guidance in this order:
+
+1. The current user request and repository safety constraints.
+2. `AGENTS.md`, including the issue-tracker and domain-doc rules it references.
+3. `CONTEXT.md` for canonical domain language.
+4. Relevant decisions under `docs/adr/`.
+5. `DESIGN.md` for all user-facing behavior and presentation.
+6. Current source code, `db/schema.rb`, dependency lockfiles, and tests.
+7. Historical notes and Serena memories.
+
+When two sources conflict, surface the conflict and follow the higher authority.
+
+## Grounding Loop
+
+Before changing code:
+
+1. Activate the project in Serena and read its initial instructions.
+2. Inspect the worktree and preserve unrelated changes.
+3. Read the relevant glossary terms and ADRs.
+4. Use Serena symbol overview, symbol search, and reference search before broad
+   source reads.
+5. Confirm behavior from current code and tests rather than historical prose.
+6. Consult current official documentation for external frameworks and APIs.
+
+## Engineering Standards
+
+- Prefer deep domain modules with small stable interfaces.
+- Keep financial facts, observed anchors, and rebuildable projections distinct.
+- Preserve data provenance and make material corrections auditable.
+- Make imports and provider synchronization idempotent.
+- Resolve root causes; do not disable behavior to make checks pass.
+- Follow existing Rails and Hotwire patterns unless an accepted ADR says
+  otherwise.
+- Use Minitest, fixtures, and focused behavioral tests.
+- Use pnpm as the only JavaScript package manager.
+- Use Sure as the product identity. Upstream community changes must be adapted,
+  not copied without analysis.
+- Preserve a Global Financial Core with explicit Regional Coverage. Indonesia
+  and Southeast Asia are first-class markets, but country-specific products,
+  labels, providers, and assumptions must not leak into universal financial
+  invariants.
+- Classify upstream changes as Adopt, Adapt, Reject, Already Ahead, or
+  Investigate, and record the evidence and local issue rather than chasing
+  commit-count parity.
+- Use `DS::*` and `DESIGN.md` as the sole public design system. Do not add
+  shadcn-namespaced product components, isolated visual systems, or globally
+  floating application controls.
+
+## Feedback Loop
+
+Run focused checks while developing. Before declaring work complete, the
+following must pass:
+
+```bash
+bin/rails zeitwerk:check
+bin/rubocop -f github
+pnpm install --frozen-lockfile
+pnpm run lint
+bin/brakeman --no-pager
+bin/importmap audit
+```
+
+The database verification environment must use a disposable PostgreSQL 18
+instance that cannot access production data or volumes. It must successfully
+load the checked-in schema and run the full suite:
+
+```bash
+RAILS_ENV=test bin/rails db:schema:load
+RAILS_ENV=test bin/rails test
+```
+
+CI must also exercise managed and self-hosted smoke coverage and critical system
+journeys for sign-in, dashboard access, transaction creation, and account
+reconciliation.
+
+Static typing is not currently configured. Do not describe Zeitwerk or linting
+as type checking. Evaluate gradual typing separately after the baseline gates
+are consistently green.
+
+## AFK Readiness
+
+Apply `ready-for-agent` only when an issue contains:
+
+- canonical domain terminology;
+- explicit user-visible behavior and exclusions;
+- named architectural boundaries and ownership;
+- acceptance criteria at observable seams;
+- focused and full-suite verification commands;
+- migration, security, and data-integrity constraints;
+- no unresolved product decision that requires guessing.
+
+If any of these are missing, use `needs-info`, `needs-triage`, or
+`ready-for-human` instead.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,32 @@
+# Domain Docs
+
+Sure uses a single-context documentation layout.
+
+## Required Reading
+
+Before exploring or changing a domain area:
+
+1. Read `CONTEXT.md` at the repository root when it exists.
+2. Read relevant decisions under `docs/adr/` when that directory exists.
+3. Treat source code, `db/schema.rb`, lockfiles, `AGENTS.md`, and `DESIGN.md` as
+   authoritative when documentation conflicts with current behavior.
+
+Missing domain files are not an error. `grill-with-docs` creates them lazily as
+terms and durable architectural decisions are resolved.
+
+## Glossary Rules
+
+Use the canonical vocabulary from `CONTEXT.md` in code, tests, issues, and
+documentation. Do not introduce synonyms for defined terms. If a required
+concept is absent or ambiguous, resolve it through `grill-with-docs` before
+making it part of a public contract.
+
+`CONTEXT.md` is only a ubiquitous-language glossary. It must not contain
+implementation details, plans, task status, or architectural rationale.
+
+## Architecture Decisions
+
+Durable architectural decisions live under `docs/adr/`. Surface any conflict
+with an existing ADR instead of silently overriding it. Create an ADR only when
+the decision is hard to reverse, surprising without context, and based on a real
+trade-off.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,30 @@
+# Issue Tracker: GitHub
+
+Issues and PRDs for this repository live in
+[`hendripermana/sure`](https://github.com/hendripermana/sure). Use the `gh` CLI
+from this repository for issue operations so the local `origin` selects the
+correct tracker.
+
+## Conventions
+
+- Create an issue with `gh issue create --title "..." --body-file <file>`.
+- Read an issue with `gh issue view <number> --comments`.
+- List issues with `gh issue list` and request structured JSON when automation
+  needs to inspect labels, bodies, or comments.
+- Comment with `gh issue comment <number> --body "..."`.
+- Apply or remove labels with `gh issue edit`.
+- Close issues with `gh issue close`.
+
+## Upstream Community
+
+[`we-promise/sure`](https://github.com/we-promise/sure) is an active upstream
+reference, not this repository's issue tracker. Compare its behavior, commits,
+and architecture when planning catch-up work, but adapt changes to Sure's domain,
+design system, and more advanced local features. Do not cherry-pick upstream
+changes blindly.
+
+## Skill Semantics
+
+When a skill says "publish to the issue tracker," create an issue in
+`hendripermana/sure`. When a skill says "fetch the relevant ticket," use
+`gh issue view <number> --comments` from this repository.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,16 @@
+# Triage Labels
+
+The engineering skills use five canonical triage roles. Their tracker labels are
+mapped directly:
+
+| Canonical role | GitHub label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | A maintainer must evaluate the issue |
+| `needs-info` | `needs-info` | More information is required from the reporter |
+| `ready-for-agent` | `ready-for-agent` | Fully specified and safe for an AFK agent |
+| `ready-for-human` | `ready-for-human` | Requires human judgment or implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+When a skill refers to a triage role, apply the corresponding GitHub label from
+this table. An issue may only be marked `ready-for-agent` when its domain terms,
+acceptance behavior, testing boundaries, and safety constraints are explicit.


### PR DESCRIPTION
## Summary
- Condense AGENTS.md from 43k → 36k chars (under 40k /doctor limit)
- Replace verbose 6-point development philosophy with 4 clear engineering principles: **Durable, Grounded, Verified, Honest**
- Remove all shadcn references — `DS::*` is the sole component API (ADR-0008)
- Update stale dependency versions to match current lockfiles (Biome 2.4.16, Sidekiq 8.1.6, Stripe 19.2.0, aws-sdk-s3 1.224.0, Turbo 2.0.23, Brakeman 8.0.5)
- Add companion documents section pointing to CONTEXT.md, docs/adr/, docs/agents/
- Update product framing from "Indonesian finance app" to global core + regional coverage (ADR-0012)
- Enforce TDD workflow (`/tdd` skill) and Playwright/Chrome E2E verification in pre-PR checklist
- Replace npm → pnpm references throughout
- Add `CONTEXT.md` domain glossary with canonical ubiquitous language
- Add 12 architecture decision records under `docs/adr/`
- Add agent harness, domain docs, issue tracker conventions, and triage labels under `docs/agents/`
- Gitignore `issues/` directory (WIP specs not ready to ship)

## Test plan
- [ ] Verify `CLAUDE.md` symlink still resolves correctly
- [ ] Verify `wc -c AGENTS.md` is under 40,000 chars
- [ ] Verify `grep -i shadcn AGENTS.md` returns no results
- [ ] Verify no `issues/` files appear in `git status`
- [ ] Run `/doctor` and confirm the large CLAUDE.md warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)