### PR TITLE
Restore and harden the full Minitest baseline (issue 003)

### DIFF
--- a/test/lib/ci_workflow_test.rb
+++ b/test/lib/ci_workflow_test.rb
@@ -71,4 +71,40 @@ class CiWorkflowTest < ActiveSupport::TestCase
     assert_match(/\Apnpm@\d+\.\d+\.\d+\z/, package["packageManager"].to_s,
       "package.json must pin an exact pnpm version via packageManager")
   end
+
+  # Guards the issue 003 contract: the full Minitest suite is a blocking CI check
+  # that runs against a freshly loaded PostgreSQL 18 database via the disposable
+  # harness — never a narrowed subset, never permissive.
+  test "the full Minitest suite runs as a blocking job on the clean PostgreSQL 18 path" do
+    test_job = @jobs.values.find do |job|
+      Array(job["steps"]).any? { |step| step["run"].to_s.include?("bin/rails test") }
+    end
+    assert test_job, "CI must run the full Minitest suite (`bin/rails test`)"
+
+    refute test_job["continue-on-error"],
+      "The test job must block on failure; remove continue-on-error"
+
+    suite_cmd = Array(test_job["steps"]).filter_map { |step| step["run"] }
+                     .find { |cmd| cmd.include?("bin/rails test") }
+    assert_includes suite_cmd, "bin/test-db",
+      "The suite must run through the disposable-database harness (bin/test-db) for a clean schema load"
+    refute_match(%r{bin/rails test\s+\S}, suite_cmd,
+      "CI must run the entire suite, not a narrowed subset of files")
+
+    postgres_image = test_job.dig("services", "postgres", "image").to_s
+    assert_equal "postgres:18", postgres_image,
+      "The suite must run against a clean PostgreSQL 18 service"
+  end
+
+  test "the test suite job is reached on pull requests" do
+    pr_workflow = YAML.safe_load(File.read(Rails.root.join(".github/workflows/pr.yml")), aliases: true)
+    triggers = pr_workflow["on"] || pr_workflow[true]
+    assert triggers.key?("pull_request"),
+      "pr.yml must trigger on pull_request so the blocking suite runs before merge"
+
+    calls_ci = pr_workflow.fetch("jobs").values.any? do |job|
+      job["uses"].to_s.include?(".github/workflows/ci.yml")
+    end
+    assert calls_ci, "pr.yml must invoke ci.yml (which contains the blocking test suite)"
+  end
 end

--- a/test/lib/database_safety_guard_test.rb
+++ b/test/lib/database_safety_guard_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Guards the issue 003 contract that the suite can never run against a
+# production database, even when conflicting POSTGRES_DB / POSTGRES_DB_PRODUCTION
+# shell variables resolve the test environment onto a production database name.
+class DatabaseSafetyGuardTest < ActiveSupport::TestCase
+  test "returns the configured database when it is a safe test database" do
+    assert_equal "sure_test", DatabaseSafetyGuard.verify!(
+      rails_env: "test",
+      configured_database: "sure_test",
+      production_database: "sure_production"
+    )
+  end
+
+  test "raises outside the test environment" do
+    error = assert_raises(DatabaseSafetyGuard::UnsafeDatabaseError) do
+      DatabaseSafetyGuard.verify!(
+        rails_env: "development",
+        configured_database: "sure_test",
+        production_database: "sure_production"
+      )
+    end
+
+    assert_match(/test environment/i, error.message)
+  end
+
+  test "raises when the configured database collides with the production database" do
+    error = assert_raises(DatabaseSafetyGuard::UnsafeDatabaseError) do
+      DatabaseSafetyGuard.verify!(
+        rails_env: "test",
+        configured_database: "sure_production",
+        production_database: "sure_production"
+      )
+    end
+
+    assert_match(/production database/i, error.message)
+  end
+
+  test "raises when the configured database is blank" do
+    assert_raises(DatabaseSafetyGuard::UnsafeDatabaseError) do
+      DatabaseSafetyGuard.verify!(
+        rails_env: "test",
+        configured_database: "",
+        production_database: "sure_production"
+      )
+    end
+  end
+
+  test "comparison ignores surrounding whitespace and case" do
+    assert_raises(DatabaseSafetyGuard::UnsafeDatabaseError) do
+      DatabaseSafetyGuard.verify!(
+        rails_env: "test",
+        configured_database: "  Sure_Production ",
+        production_database: "sure_production"
+      )
+    end
+  end
+end

--- a/test/lib/turbo_broadcast_helper_availability_test.rb
+++ b/test/lib/turbo_broadcast_helper_availability_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Regression guard for the order-dependent flakiness fixed in issue 003.
+#
+# turbo-rails only requires and mixes Turbo::Broadcastable::TestHelper into
+# ActiveSupport::TestCase from inside an `on_load(:action_cable)` hook. Because
+# ActionCable loads lazily, parallel workers that ran a Turbo-broadcast test
+# before ActionCable was loaded raised `NoMethodError: undefined method
+# 'capture_turbo_stream_broadcasts'`. test_helper now touches
+# ActionCable::Server::Base so the hook fires in the parent process before
+# workers fork. This test fails loudly if that wiring is removed.
+class TurboBroadcastHelperAvailabilityTest < ActiveSupport::TestCase
+  test "capture_turbo_stream_broadcasts is available to every test case" do
+    assert defined?(Turbo::Broadcastable::TestHelper),
+      "ActionCable must be loaded so turbo-rails defines its broadcast test helper"
+
+    assert_includes ActiveSupport::TestCase.ancestors, Turbo::Broadcastable::TestHelper,
+      "Turbo::Broadcastable::TestHelper must be mixed into ActiveSupport::TestCase " \
+      "so capture_turbo_stream_broadcasts is available in every parallel worker"
+
+    assert_respond_to self, :capture_turbo_stream_broadcasts
+  end
+end

--- a/test/support/database_safety_guard.rb
+++ b/test/support/database_safety_guard.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Defense-in-depth guard ensuring the Minitest suite can never run against a
+# production database, even when conflicting POSTGRES_DB / POSTGRES_DB_PRODUCTION
+# shell variables resolve the test environment onto a production database name
+# (issue 003, acceptance criterion #4).
+#
+# `verify!` holds the pure decision so it can be unit-tested without aborting the
+# process. `enforce!` wraps it for `test_helper`, translating a violation into a
+# hard `abort` before Rails' `maintain_test_schema!` can purge a real database.
+module DatabaseSafetyGuard
+  class UnsafeDatabaseError < StandardError; end
+
+  module_function
+
+  # Returns the configured database name when it is a safe test database,
+  # otherwise raises UnsafeDatabaseError describing the violation.
+  def verify!(rails_env:, configured_database:, production_database:)
+    unless rails_env.to_s == "test"
+      raise UnsafeDatabaseError,
+        "Refusing to run the test suite outside the test environment " \
+        "(RAILS_ENV=#{rails_env.inspect})."
+    end
+
+    configured = normalize(configured_database)
+
+    if configured.empty?
+      raise UnsafeDatabaseError,
+        "Refusing to run the test suite: no test database is configured."
+    end
+
+    if configured == normalize(production_database)
+      raise UnsafeDatabaseError,
+        "Refusing to run the test suite against the production database " \
+        "#{configured_database.to_s.strip.inspect}. Set POSTGRES_DB_TEST to a " \
+        "dedicated test database that does not collide with POSTGRES_DB / " \
+        "POSTGRES_DB_PRODUCTION."
+    end
+
+    configured_database.to_s.strip
+  end
+
+  # Verifies the live configuration and aborts the process on any violation so
+  # no schema maintenance touches a production database.
+  def enforce!(rails_env:, configured_database:, production_database:)
+    verify!(
+      rails_env: rails_env,
+      configured_database: configured_database,
+      production_database: production_database
+    )
+  rescue UnsafeDatabaseError => error
+    abort("FATAL: #{error.message}")
+  end
+
+  def normalize(value)
+    value.to_s.strip.downcase
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,10 +62,30 @@ ENV["API_RATE_LIMITING_ENABLED"] ||= "true"
 # Fixes Segfaults on M1 Macs when running tests in parallel (temporary workaround)
 ENV["PGGSSENCMODE"] = "disable"
 
+# Defense-in-depth: never let the suite (and the schema maintenance triggered by
+# `rails/test_help`) run against a production database, even when conflicting
+# POSTGRES_DB / POSTGRES_DB_PRODUCTION shell variables leak in (issue 003 AC#4).
+require_relative "support/database_safety_guard"
+DatabaseSafetyGuard.enforce!(
+  rails_env: Rails.env,
+  configured_database: ActiveRecord::Base.connection_db_config.database,
+  production_database: ENV["POSTGRES_DB_PRODUCTION"].presence ||
+    ENV["POSTGRES_DB"].presence || "permoney_production"
+)
+
 require "rails/test_help"
 require "minitest/autorun"
 require "mocha/minitest"
 require "aasm/minitest"
+
+# turbo-rails only mixes Turbo::Broadcastable::TestHelper (which provides
+# `capture_turbo_stream_broadcasts`) into ActiveSupport::TestCase from inside an
+# `on_load(:action_cable)` hook. ActionCable loads lazily, so in any parallel
+# worker where it has not been loaded before the test runs, the helper is
+# missing and tests fail with an order-dependent NoMethodError. Touching
+# ActionCable::Server::Base here fires the load hook in the parent process,
+# before parallel workers fork, so the helper is present everywhere. (issue 003)
+ActionCable::Server::Base.config
 
 VCR.configure do |config|
   config.cassette_library_dir = "test/vcr_cassettes"


### PR DESCRIPTION
## Summary

Restores the full Minitest baseline for issue `003-restore-full-minitest-baseline` (parent PRD `000-stabilize-sure-prd`). The checked-in suite is proven green on a clean PostgreSQL 18 schema and the guarantees the issue requires are locked in.

The suite was already green on a single run, but **not deterministic** — a seed-dependent ordering surfaced a real order-dependent failure. This PR fixes that at the root and hardens the harness.

## Changes

- **Fix order-dependent flakiness** (`capture_turbo_stream_broadcasts`). turbo-rails only requires and mixes `Turbo::Broadcastable::TestHelper` into `ActiveSupport::TestCase` from inside an `on_load(:action_cable)` hook, and ActionCable loads lazily. In parallel workers where ActionCable had not yet loaded, the helper (and even its constant) was absent — under seed 7 this raised `NoMethodError: undefined method 'capture_turbo_stream_broadcasts'`. `test_helper` now touches `ActionCable::Server::Base` so the hook fires in the parent process before workers fork. Proven load-bearing: without the touch the constant is `UNDEFINED`; with it the helper is mixed in. A regression guard (`turbo_broadcast_helper_availability_test`) fails loudly if the wiring is removed.

- **Production-database safety guard** (AC#4). New `DatabaseSafetyGuard`, wired into `test_helper` *before* `rails/test_help` runs schema maintenance. It aborts the suite when conflicting `POSTGRES_DB` / `POSTGRES_DB_PRODUCTION` shell variables resolve the test environment onto a production database name (verified: such a config otherwise resolves the test env to `sure_production`). Pure decision logic is unit-tested; the wired path was verified to exit non-zero before any DB access.

- **Blocking full-suite CI guard** (AC#7). Extends `ci_workflow_test` to assert the full Minitest suite stays a blocking job that runs the **entire** suite (not a narrowed subset) through the disposable `bin/test-db` harness against a clean **PostgreSQL 18** service, and is reached on every pull request via `pr.yml → ci.yml`.

## Verification

Deterministic across modes and seeds (clean schema load via `bin/test-db`):

```
PARALLEL     seed 1       1903 runs, 0 failures, 0 errors, 19 skips
PARALLEL     seed 13337   1903 runs, 0 failures, 0 errors, 19 skips
PARALLEL     seed 424242  1903 runs, 0 failures, 0 errors, 19 skips
NON-PARALLEL seed 9001    1903 runs, 0 failures, 0 errors, 19 skips
```

Pre-PR loop all green: `zeitwerk:check`, `rubocop`, `pnpm run lint`, `brakeman` (0 warnings), `importmap audit` (no vulnerabilities).

## Notes / honest scope

- **The 19 skips are pre-existing and intentional**, not failures hidden by this work: i18n tests (ignored per project policy), environment-gated Rack::Attack throttles, and TODO/quarantine stubs for features owned by other PRD child issues (PayLater, exchange rates, API scopes, auto-sync). None mask a failure in the current suite. Un-skipping them would create a red suite for unbuilt features, which is out of scope for "restore baseline."
- **Global test_helper masks** (Redis in-memory fake, `Provider::Openai` test mock, forced managed mode) were assessed for AC#3. They are minimal and load-bearing for a hermetic, network-free, Redis-less suite: the Redis fake implements exactly the 6 methods its only two real consumers use (`ApiRateLimiter`, the self-hosting `Redis.new.ping` check), and rate-limiter tests explicitly manage their own keys via `Redis.new.del` in setup/teardown. They do not hide failures and the suite is deterministic with them in place; removing them would add flakiness/network dependence with no observed defect, so they are preserved.
- True merge-blocking also requires the "Test Suite (PostgreSQL 18)" check to be a required status check in branch protection (a GitHub repo setting outside the repo). The workflow-level path is enforced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)